### PR TITLE
fix: Fixed error during route creation when using MySQL as a DB

### DIFF
--- a/registry/server/appRoutes/routes/createAppRoute.ts
+++ b/registry/server/appRoutes/routes/createAppRoute.ts
@@ -43,7 +43,7 @@ const createAppRoute = async (req: Request, res: Response) => {
     });
 
     const savedAppRoute = await db
-        .select('routes.id as routeId', 'route_slots.id as routeSlotId', '*')
+        .select('routes.id as routeId', 'route_slots.id as routeSlotId', 'routes.*', 'route_slots.*')
         .from('routes')
         .where('routeId', savedAppRouteId)
         .join('route_slots', {


### PR DESCRIPTION
Error example: 
```
select `routes`.`id` as `routeId`, `route_slots`.`id` as `routeSlotId`, * from `routes` inner join `route_slots` on `route_slots`.`routeId` = `routes`.`id` where `routeId` = 4 - ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '* from `routes` inner join `route_slots` on `route_slots`.`routeId` = `routes`.
```