### PR TITLE
feat!: fixed work with AMD modules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ And don't miss the **[Step-By-Step lessons about apps development with ILC](./do
 * [Global error handling](./docs/global_errors_handling.md)
 * [Demo applications used in quick start](https://github.com/namecheap/ilc-demo-apps)
 * [SDK for ILC plugins development](https://github.com/namecheap/ilc-plugins-sdk)
+* [Compatibility with legacy UMD bundles](./docs/umd_bundles_compatibility.md)
 
 ## 🔌 Adapters
 To conveniently connect various frameworks to ILC we rely on the [ecosystem of the single-spa](https://single-spa.js.org/docs/ecosystem)

--- a/docs/umd_bundles_compatibility.md
+++ b/docs/umd_bundles_compatibility.md
@@ -1,0 +1,39 @@
+# Compatibility with legacy UMD bundles
+
+When adding ILC to the legacy website - sometimes you may face an issue when code that you still 
+load via regular `<script>` tags may work incorrectly. This happens when you load external libraries packed as UMD bundles.
+
+By default, ILC exposes `window.define` variable - which forces all UMD bundles to be registered within ILC (through System.js).
+While this approach is convenient for the new projects - it may break things on the legacy ones. 
+As without ILC and System.js running you expect content of the UMD bundle to be registered as window variable.
+
+In order to fix the issue - you need to run ILC Docker container with the following environment variable in place:
+`AMD_DEFINE_COMPATIBILITY_MODE=true`.
+
+This will remove `window.define` variable so all your libs should instead use `window.ILC.define`.
+
+When using webpack - here is how you can force usage of `window.ILC.define` while building the apps for ILC:
+
+```javascript
+const WrapperPlugin = require('wrapper-webpack-plugin');
+
+module.exports = {
+    entry: 'src/app.js',
+    output: {
+        filename: 'app.js',
+        libraryTarget: 'amd',
+    },
+    module: { /* ... */ },
+    plugins: [
+        new WrapperPlugin({
+            test: /\.js$/, // only wrap output of bundle files with '.js' extension
+            header: '(function(define){\n',
+            footer: '\n})((window.ILC && window.ILC.define) || window.define);'
+        }),
+    ],
+};
+
+
+```
+
+ 

--- a/ilc/client.js
+++ b/ilc/client.js
@@ -22,6 +22,12 @@ const state = initIlcState();
 const router = new Router(registryConf, state, singleSpa);
 const asyncBootUp = new AsyncBootUp();
 
+// Here we expose window.ILC.define also as window.define to ensure that regular AMD/UMD bundles work correctly by default
+// See docs/umd_bundles_compatibility.md
+if (!registryConf.settings.amdDefineCompatibilityMode) {
+    window.define = window.ILC.define;
+}
+
 selectSlotsToRegister([...registryConf.routes, registryConf.specialRoutes['404']]).forEach((slots) => {
     Object.keys(slots).forEach((slotName) => {
         const appName = slots[slotName].appName;

--- a/ilc/config/custom-environment-variables.json5
+++ b/ilc/config/custom-environment-variables.json5
@@ -7,5 +7,9 @@
         licenseKey: 'NR_LICENSE_KEY',
         customClientJsWrapper: 'NR_CUSTOM_CLIENT_JS_WRAPPER',
     },
-    overrideConfigTrustedOrigins: 'OVERRIDE_CONFIG_TRUSTED_ORIGINS'
+    overrideConfigTrustedOrigins: 'OVERRIDE_CONFIG_TRUSTED_ORIGINS',
+    amdDefineCompatibilityMode: {
+        __name: 'AMD_DEFINE_COMPATIBILITY_MODE',
+        __format: 'json',
+    },
 }

--- a/ilc/config/default.json5
+++ b/ilc/config/default.json5
@@ -12,5 +12,6 @@
          */
         customClientJsWrapper: null,
     },
-    overrideConfigTrustedOrigins: null
+    overrideConfigTrustedOrigins: null,
+    amdDefineCompatibilityMode: false, //TODO: should be moved to registry, see also docs/umd_bundles_compatibility.md
 }

--- a/ilc/server/tailor/fetch-template.js
+++ b/ilc/server/tailor/fetch-template.js
@@ -20,6 +20,9 @@ module.exports = (templatesPath, router, configsInjector, newrelic, registryServ
     parseTemplate
 ) => {
     const registryConfig = await registryService.getConfig();
+    registryConfig.data.settings = { //TODO: this object should be fetched from registry
+        amdDefineCompatibilityMode: config.get('amdDefineCompatibilityMode'),
+    };
     const overrideConfig = parseOverrideConfig(request.headers.cookie, config.get('overrideConfigTrustedOrigins'));
     if (overrideConfig) {
         registryConfig.data = mergeConfigs(registryConfig.data, overrideConfig);


### PR DESCRIPTION
This also fixed "ReactDOM was loaded before React" at demo website