### PR TITLE
Increase db text types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .vscode
 /dbfiles
 /mkdocs_dist
+registry/lde/dbfiles

--- a/registry/lde/docker-compose.yml
+++ b/registry/lde/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "2.4"
+services:
+  mysql:
+    platform: linux/x86_64
+    image: mysql:5.7
+    volumes:
+      - "./dbfiles:/var/lib/mysql"
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: pwd
+      MYSQL_DATABASE: ilc

--- a/registry/server/migrations/20220315155008_increase-template-size.ts
+++ b/registry/server/migrations/20220315155008_increase-template-size.ts
@@ -1,0 +1,16 @@
+import { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('templates', table => {
+        table.text('content', 'mediumtext').alter({});
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('templates', table => {
+        table.text('content').alter({});
+    });
+}
+

--- a/registry/server/migrations/20220316133143_versioning-text-update.ts
+++ b/registry/server/migrations/20220316133143_versioning-text-update.ts
@@ -1,0 +1,18 @@
+import { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('versioning', table => {
+        table.text('data', 'mediumtext').alter({});
+        table.text('data_after', 'mediumtext').alter({});
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('versioning', table => {
+        table.text('data').alter({});
+        table.text('data_after').alter({});
+    });
+}
+


### PR DESCRIPTION
Registry stores templates in DB with type text which by default has 60kb capacity. 
The issue we faced is 500 page templates with accumulated styles and images in template. Since template storage is DB I think it is reasonable to allow mediumtext type for texts