### PR TITLE
chore: change config format due to env var is string

### DIFF
--- a/ilc/config/default.json5
+++ b/ilc/config/default.json5
@@ -15,7 +15,7 @@
     overrideConfigTrustedOrigins: null,
     logger: {
         accessLog: {
-            ignoreUrls: []
+            ignoreUrls: ''
         }
     }
 }

--- a/ilc/server/app.js
+++ b/ilc/server/app.js
@@ -28,7 +28,7 @@ module.exports = (registryService, pluginManager) => {
 
     app.addHook('onRequest', async (req, reply) => {
 
-        const ignoredUrls = config.get('logger.accessLog.ignoreUrls');
+        const ignoredUrls = config.get('logger.accessLog.ignoreUrls').split(',');
         const currentUrl = req.raw.url;
 
         if(!ignoredUrls.includes(currentUrl)) {
@@ -44,7 +44,7 @@ module.exports = (registryService, pluginManager) => {
 
     app.addHook("onResponse", (req, reply, done) => {
 
-        const ignoredUrls = config.get('logger.accessLog.ignoreUrls');
+        const ignoredUrls = config.get('logger.accessLog.ignoreUrls').split(',');
         const currentUrl = req.raw.url;
 
         if(!ignoredUrls.includes(currentUrl)) {


### PR DESCRIPTION
Considering BC rules ignore urls params should be passed as env variable.
env variable is passed as string in node process so in runtime we should work with string 