### PR TITLE
fix: newrelic native metrics were not installed in previous commit be…

### DIFF
--- a/ilc/Dockerfile
+++ b/ilc/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /codebase
 
 COPY package-lock.json package.json /codebase/
 RUN npm ci --no-package-lock --ignore-scripts
+RUN npm rebuild @newrelic/native-metrics
 
 COPY ./ /codebase
 

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -12,6 +12,7 @@ COPY package-lock.json package.json /codebase/
 RUN npm ci --no-package-lock --ignore-scripts
 RUN npm rebuild bcrypt --build-from-source
 RUN npm rebuild @vscode/sqlite3
+RUN npm rebuild @newrelic/native-metrics
 RUN npm install mysql
 
 COPY client/package-lock.json client/package.json /codebase/client/


### PR DESCRIPTION
…cause dockerfile uses --ignore-scripts during npm ci command, which does not build native metrics plugin.