### PR TITLE
fix: correct behaviour of Header setCookie=ilc-i18n

### DIFF
--- a/ilc/common/utils.js
+++ b/ilc/common/utils.js
@@ -30,6 +30,9 @@ const uniqueArray = array => [...new Set(array)];
 const encodeHtmlEntities = value => value.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 const decodeHtmlEntities = value => value.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"');
 
+const fakeBaseInCasesWhereUrlIsRelative = 'http://hack';
+const parseUrl = (url) => new URL(url, fakeBaseInCasesWhereUrlIsRelative);
+
 module.exports = {
     appIdToNameAndSlot,
     makeAppId,
@@ -37,4 +40,5 @@ module.exports = {
     uniqueArray,
     encodeHtmlEntities,
     decodeHtmlEntities,
+    parseUrl,
 }

--- a/ilc/package-lock.json
+++ b/ilc/package-lock.json
@@ -34,7 +34,7 @@
         "single-spa": "5.6.0",
         "systemjs": "6.10.1",
         "systemjs-css-extra": "^1.0.2",
-        "tailorx": "^7.0.0",
+        "tailorx": "^7.0.1",
         "url-join": "^4.0.1",
         "uuid": "^3.4.0"
       },
@@ -11405,9 +11405,9 @@
       "integrity": "sha512-crSqrulcJAubWxDzas/Tw9aGK8Pi0lBMhwzSE2U4LZaHlmuX0W/qgzHLBVnO+krkbIns3ayUhQVZZUdE2+SGaA=="
     },
     "node_modules/tailorx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tailorx/-/tailorx-7.0.0.tgz",
-      "integrity": "sha512-TG5WpRY/TfmlC4EBH4otf/l2Jc6NwrQDDJGlofmxxNLduru3jVx8fWBmZiSlim+SGE0Go5C2Z8ZUMDOi5ZO4uQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/tailorx/-/tailorx-7.0.1.tgz",
+      "integrity": "sha512-WoiiNBsggqkq1TJX1fwpKVIFwgNFp+fNM4zCT0sLy4JZwWZrtaO2kJQK/0BImkda9n4N6viOx0BcmFGl6UaLWQ==",
       "dependencies": {
         "@namecheap/error-extender": "^1.1.1",
         "agentkeepalive": "^4.1.0",
@@ -22437,9 +22437,9 @@
       "integrity": "sha512-crSqrulcJAubWxDzas/Tw9aGK8Pi0lBMhwzSE2U4LZaHlmuX0W/qgzHLBVnO+krkbIns3ayUhQVZZUdE2+SGaA=="
     },
     "tailorx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tailorx/-/tailorx-7.0.0.tgz",
-      "integrity": "sha512-TG5WpRY/TfmlC4EBH4otf/l2Jc6NwrQDDJGlofmxxNLduru3jVx8fWBmZiSlim+SGE0Go5C2Z8ZUMDOi5ZO4uQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/tailorx/-/tailorx-7.0.1.tgz",
+      "integrity": "sha512-WoiiNBsggqkq1TJX1fwpKVIFwgNFp+fNM4zCT0sLy4JZwWZrtaO2kJQK/0BImkda9n4N6viOx0BcmFGl6UaLWQ==",
       "requires": {
         "@namecheap/error-extender": "^1.1.1",
         "agentkeepalive": "^4.1.0",

--- a/ilc/package.json
+++ b/ilc/package.json
@@ -45,7 +45,7 @@
     "single-spa": "5.6.0",
     "systemjs": "6.10.1",
     "systemjs-css-extra": "^1.0.2",
-    "tailorx": "^7.0.0",
+    "tailorx": "^7.0.1",
     "url-join": "^4.0.1",
     "uuid": "^3.4.0"
   },

--- a/ilc/server/i18n.js
+++ b/ilc/server/i18n.js
@@ -4,8 +4,14 @@ const {intlSchema} = require('ilc-sdk/dist/server/IlcProtocol'); // "Private" im
 
 const i18nCookie = require('../common/i18nCookie');
 
+const isStaticFile = url => {
+    const extensions = ['.js', '.js.map'];
+
+    return extensions.some(ext => url.endsWith(ext));
+};
+
 const onRequestFactory = (i18nConfig, i18nParamsDetectionPlugin) => async (req, reply) => {
-    if (!i18nConfig.enabled || req.raw.url === '/ping') {
+    if (!i18nConfig.enabled || req.raw.url === '/ping' || isStaticFile(req.raw.url)) {
         return; // Excluding system routes
     }
 

--- a/ilc/server/i18n.js
+++ b/ilc/server/i18n.js
@@ -3,6 +3,7 @@ const IlcIntl = require('ilc-sdk/app').IlcIntl;
 const {intlSchema} = require('ilc-sdk/dist/server/IlcProtocol'); // "Private" import
 
 const i18nCookie = require('../common/i18nCookie');
+const { parseUrl } = require('../common/utils');
 
 const isStaticFile = url => {
     const extensions = ['.js', '.js.map'];
@@ -11,7 +12,9 @@ const isStaticFile = url => {
 };
 
 const onRequestFactory = (i18nConfig, i18nParamsDetectionPlugin) => async (req, reply) => {
-    if (!i18nConfig.enabled || req.raw.url === '/ping' || isStaticFile(req.raw.url)) {
+    const parsedUrl = parseUrl(req.raw.url);
+
+    if (!i18nConfig.enabled || req.raw.url === '/ping' || isStaticFile(parsedUrl.pathname)) {
         return; // Excluding system routes
     }
 


### PR DESCRIPTION
1) previously clinet.js (ILC bundle) could set header (set-cookie=i18n). it caused unpredictable bugs. 
2) update of TailorX fixes the bug with overriding ILC's Headers by fragments Headers https://github.com/StyleT/tailorx/commit/2d83fd5fb89666ee3e0c93022e5a1a54e0333d9f