### PR TITLE
feat: allow to disable automatic injection of NewRelic browser monitoring on a page.

### DIFF
--- a/ilc/config/custom-environment-variables.json5
+++ b/ilc/config/custom-environment-variables.json5
@@ -6,6 +6,7 @@
     newrelic: {
         licenseKey: 'NR_LICENSE_KEY',
         customClientJsWrapper: 'NR_CUSTOM_CLIENT_JS_WRAPPER',
+        automaticallyInjectBrowserMonitoring: 'NR_CUSTOM_CLIENT_AUTO_INJECT'
     },
     overrideConfigTrustedOrigins: 'OVERRIDE_CONFIG_TRUSTED_ORIGINS',
     logger: {

--- a/ilc/config/default.json5
+++ b/ilc/config/default.json5
@@ -11,6 +11,7 @@
          * Usage example: <script type="text/javascript">(function mygdprWrapper(){ %CONTENT% })()</script>
          */
         customClientJsWrapper: null,
+        automaticallyInjectBrowserMonitoring: true
     },
     overrideConfigTrustedOrigins: null,
     logger: {

--- a/ilc/server/app.js
+++ b/ilc/server/app.js
@@ -64,6 +64,7 @@ module.exports = (registryService, pluginManager) => {
         registryService,
         config.get('cdnUrl'),
         config.get('newrelic.customClientJsWrapper'),
+        config.get('newrelic.automaticallyInjectBrowserMonitoring')
     );
 
     if (config.get('cdnUrl') === null) {

--- a/ilc/server/tailor/factory.js
+++ b/ilc/server/tailor/factory.js
@@ -13,8 +13,8 @@ const ConfigsInjector = require('./configs-injector');
 const processFragmentResponse = require('./process-fragment-response');
 const requestFragment = require('./request-fragment');
 
-module.exports = function (registryService, cdnUrl, nrCustomClientJsWrapper = null) {
-    const configsInjector = new ConfigsInjector(newrelic, cdnUrl, nrCustomClientJsWrapper);
+module.exports = function (registryService, cdnUrl, nrCustomClientJsWrapper = null, nrAutomaticallyInjectClientScript = true) {
+    const configsInjector = new ConfigsInjector(newrelic, cdnUrl, nrCustomClientJsWrapper, nrAutomaticallyInjectClientScript);
 
     const tailor = new Tailor({
         fetchContext: async function (request) {


### PR DESCRIPTION
This is a pre-requisite for removing it at all, because it harms more right now that gives benefits (see code comment for more details).