### PR TITLE
fix: reading boolean config value for newly added autoinject, because…

### DIFF
--- a/ilc/server/app.js
+++ b/ilc/server/app.js
@@ -60,11 +60,15 @@ module.exports = (registryService, pluginManager) => {
         done();
     });
 
+    const autoInjectNrMonitoringConfig = config.get('newrelic.automaticallyInjectBrowserMonitoring');
+    const autoInjectNrMonitoring = typeof autoInjectNrMonitoringConfig === 'boolean'
+        ? autoInjectNrMonitoringConfig
+        : autoInjectNrMonitoringConfig !== 'false';
     const tailor = tailorFactory(
         registryService,
         config.get('cdnUrl'),
         config.get('newrelic.customClientJsWrapper'),
-        config.get('newrelic.automaticallyInjectBrowserMonitoring')
+        autoInjectNrMonitoring
     );
 
     if (config.get('cdnUrl') === null) {


### PR DESCRIPTION
… if config value is set through the environment variable it will always be string.