### PR TITLE
fix: case when CSS removed immediately but due to spinner cloned node…

### DIFF
--- a/ilc/client/BundleLoader.js
+++ b/ilc/client/BundleLoader.js
@@ -6,9 +6,15 @@ export class BundleLoader {
     #cache = new WeakMap();
     #registryApps;
     #systemJs;
+    #delayCssRemoval;
 
     constructor(registryConf, systemJs) {
         this.#registryApps = registryConf.apps;
+        this.#delayCssRemoval = registryConf.settings && registryConf.settings.globalSpinner && registryConf.settings.globalSpinner.enabled;
+        if (typeof this.#delayCssRemoval === 'undefined') {
+            this.#delayCssRemoval = true;
+        }
+
         this.#systemJs = systemJs;
     }
 
@@ -31,11 +37,10 @@ export class BundleLoader {
 
     loadApp(appName) {
         const app = this.#getApp(appName);
-
         return this.#systemJs.import(appName)
             .then(appBundle => {
                 const rawCallbacks = this.#getAppSpaCallbacks(appBundle, app.props);
-                return typeof app.cssBundle === 'string' ? new CssTrackedApp(rawCallbacks, app.cssBundle) : rawCallbacks;
+                return typeof app.cssBundle === 'string' ? new CssTrackedApp(rawCallbacks, app.cssBundle, this.#delayCssRemoval) : rawCallbacks;
             })
     }
 

--- a/ilc/client/TransitionManager/TransitionManager.js
+++ b/ilc/client/TransitionManager/TransitionManager.js
@@ -5,6 +5,7 @@ import NamedTransactionBlocker from './NamedTransitionBlocker';
 import singleSpaEvents from '../constants/singleSpaEvents';
 import ilcEvents from '../constants/ilcEvents';
 import TransitionBlockerList from './TransitionBlockerList';
+import { CssTrackedApp } from '../CssTrackedApp';
 
 export const slotWillBe = {
     rendered: 'rendered',
@@ -39,7 +40,7 @@ export class TransitionManager {
 
         this.#logger = logger;
         this.#spinnerConfig = Object.assign({}, defaultSpinnerConfig, spinnerConfig);
-        
+
         this.#addEventListeners();
     }
 
@@ -171,13 +172,14 @@ export class TransitionManager {
 
     #onPageReady = () => {
         this.#fakeSlots.forEach(node => node.remove());
+        CssTrackedApp.removeAllNodesPendingRemoval();
         this.#fakeSlots.length = 0;
         this.#hiddenSlots.forEach(node => {
             node.style.display = '';
             node.hasAttribute('ilc-fake-slot-rendered') && node.removeAttribute('ilc-fake-slot-rendered')
         });
         this.#hiddenSlots.length = 0;
-        
+
         this.#removeGlobalSpinner();
         document.body.removeAttribute('name');
 
@@ -205,7 +207,7 @@ export class TransitionManager {
             timer = setTimeout(() => {
                 resolve();
             }, this.#spinnerConfig.minimumVisible);
-            
+
             forceResolve = resolve;
         }).onDestroy(() => {
             timer && clearTimeout(timer);
@@ -284,7 +286,7 @@ export class TransitionManager {
 
         const removingNotSpinnerBlockerAsLastOne = this.#transitionBlockers.size() === 0
             && blockerId !== this.#forceShowSpinnerBlockerId;
-        
+
         if (this.#transitionBlockers.size() === 0) {
             this.#onPageReady();
         }


### PR DESCRIPTION
… of application is still alive.

Generic logic of ILC when spinner is enabled is that app is unmounted, but original app node is cloned in DOM and alive while spinner is in progress. That is why if spinner is enabled CSS should not be removed from DOM immediately, instead we need to wait for all transitions and remove CSS only then.