### PR TITLE
fix: fixed doubled transition manager when wrapped app is created.

### DIFF
--- a/ilc/client/Client.js
+++ b/ilc/client/Client.js
@@ -74,7 +74,7 @@ export class Client {
 
         const i18nSettings = this.#configRoot.getSettingsByKey('i18n');
 
-        if (i18nSettings.enabled) { 
+        if (i18nSettings.enabled) {
             this.#i18n = new I18n(i18nSettings, {
                     ...singleSpa,
                     triggerAppChange,
@@ -206,7 +206,7 @@ export class Client {
 
         // TODO: window.ILC.importLibrary - calls bootstrap function with props (if supported), and returns exposed API
         // TODO: window.ILC.importParcelFromLibrary - same as importParcelFromApp, but for libs
-        registerSpaApps(this.#configRoot, this.#router, this.#errorHandlerFor.bind(this), this.#bundleLoader);
+        registerSpaApps(this.#configRoot, this.#router, this.#errorHandlerFor.bind(this), this.#bundleLoader, this.#transitionManager);
 
         setNavigationErrorHandler(this.#onNavigationError.bind(this));
         window.addEventListener('error', this.#onRuntimeError.bind(this));
@@ -261,7 +261,7 @@ export class Client {
         if (!this.#configRoot.getConfig().settings.amdDefineCompatibilityMode) {
             window.define = window.ILC.define;
         }
-        
+
         const parcelApi = new ParcelApi(this.#configRoot.getConfig(), this.#bundleLoader, this.#getAppSdkAdapter.bind(this));
 
         Object.assign(window.ILC, {

--- a/ilc/client/TransitionManager/TransitionManager.spec.js
+++ b/ilc/client/TransitionManager/TransitionManager.spec.js
@@ -623,7 +623,18 @@ describe('TransitionManager', () => {
         chai.expect(spinner.getRef()).to.be.null;
     });
 
+    it('should throw error in case of double subscription to single SPA events', function () {
+        chai.expect(function() {
+            new TransitionManager(logger, {
+                enabled: true,
+                customHTML: `<div id="${spinner.id}" class="${spinner.class}">Hello! I am Spinner</div>`
+            });
+        }).to.throw();
+    });
+
     it('should run scripts in customHTML', async () => {
+        removePageTransactionListeners();
+
         const expectedClass = 'iAmSetFromCustomHTML';
 
         const transitionManager = new TransitionManager(logger, {
@@ -633,6 +644,8 @@ describe('TransitionManager', () => {
                 <script>document.querySelector('#${spinner.id}').classList.add('${expectedClass}')</script>
             `
         });
+
+        removePageTransactionListeners = transitionManager.removeEventListeners.bind(transitionManager);
         const handlePageTransition = transitionManager.handlePageTransition.bind(transitionManager);
 
         applications.navbar.appendApplication();

--- a/ilc/client/WrapApp.js
+++ b/ilc/client/WrapApp.js
@@ -1,5 +1,5 @@
 import {flattenFnArray} from './utils';
-import transitionManager, {slotWillBe} from './TransitionManager/TransitionManager';
+import {slotWillBe} from './TransitionManager/TransitionManager';
 import {appIdToNameAndSlot} from '../common/utils';
 
 const APP_STATES = {
@@ -18,9 +18,9 @@ export default class WrapApp {
     #appState = 0;
     #wrapperState = 0;
 
-    constructor(wrapperConf, ssrOverrideProps) {
+    constructor(wrapperConf, ssrOverrideProps, transitionManager) {
         this.#wrapperConf = wrapperConf;
-        this.#transitionManager = transitionManager();
+        this.#transitionManager = transitionManager;
 
         if (ssrOverrideProps) {
             this.#appExtraProps = ssrOverrideProps;

--- a/ilc/client/WrapApp.spec.js
+++ b/ilc/client/WrapApp.spec.js
@@ -1,6 +1,8 @@
 import WrapApp from './WrapApp';
 import chai from 'chai';
 import sinon from 'sinon';
+import { getIlcConfigRoot } from './configuration/getIlcConfigRoot';
+import { TransitionManager } from './TransitionManager/TransitionManager';
 
 describe('WrapApp', () => {
     const appCallbacksFake = {
@@ -116,9 +118,15 @@ describe('WrapApp', () => {
         }
     }
 
+    let transitionManager;
+
     beforeEach(() => {
         initFakeIlcConfig();
         initFakeSlot('body');
+
+        const ilcConfigRoot = getIlcConfigRoot();
+        const ilcConfigSettings = ilcConfigRoot.getSettings();
+        transitionManager = new TransitionManager(window.console, ilcConfigSettings && ilcConfigSettings.globalSpinner);
     });
 
     afterEach(() => {
@@ -126,12 +134,14 @@ describe('WrapApp', () => {
         wrapperCallbacksFakeResetHistory();
         appCallbacksFakeArrayResetHistory();
         wrapperCallbacksFakeArrayResetHistory();
+        transitionManager.removeEventListeners();
     });
 
     it('should bootstrap wrapper', async () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -146,6 +156,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -160,6 +171,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -175,6 +187,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -190,6 +203,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -206,6 +220,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -222,6 +237,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -246,6 +262,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -269,6 +286,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -298,6 +316,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -321,6 +340,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -350,6 +370,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -373,6 +394,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -402,6 +424,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -416,6 +439,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -445,6 +469,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -460,6 +485,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -476,6 +502,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -492,6 +519,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -515,6 +543,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { appId: 'wrapper__at__body', kind: 'wrapper', spaBundle: 'http://localhost/client-entry.js', props: { prop: 'value' } },
             { fromLocation: 1, propFromWrapper: 'AAAAA' },
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -546,6 +575,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -571,6 +601,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -596,6 +627,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -617,6 +649,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -638,6 +671,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -676,6 +710,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount, unmount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);
@@ -726,6 +761,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFake, wrapperCallbacksFake);
@@ -751,6 +787,7 @@ describe('WrapApp', () => {
         const wrapApp = new WrapApp(
             { spaBundle: 'http://localhost/client-entry.js', kind: 'wrapper', appId: 'wrapper__at__body', props: { prop: 'value' } },
             null,
+            transitionManager,
         );
 
         const { bootstrap, mount } = wrapApp.wrapWith(appCallbacksFakeArray, wrapperCallbacksFakeArray);

--- a/ilc/client/i18n.js
+++ b/ilc/client/i18n.js
@@ -1,7 +1,6 @@
 import { IlcIntl } from 'ilc-sdk/app';
 import Cookies from 'js-cookie';
 
-import transitionManagerFactory from './TransitionManager/TransitionManager';
 import {appIdToNameAndSlot} from '../common/utils';
 import i18nCookie from '../common/i18nCookie';
 import dispatchSynchronizedEvent from './dispatchSynchronizedEvent';
@@ -25,7 +24,7 @@ export default class I18n {
         this.#config = config;
         this.#singleSpa = singleSpa;
         this.#appErrorHandlerFactory = appErrorHandlerFactory;
-        this.#transitionManager = transitionManager || transitionManagerFactory();
+        this.#transitionManager = transitionManager;
 
         this.#prevConfig = this.#get();
 

--- a/ilc/client/registerSpaApps.js
+++ b/ilc/client/registerSpaApps.js
@@ -9,7 +9,7 @@ import AsyncBootUp from './AsyncBootUp';
 import ilcEvents from './constants/ilcEvents';
 import { SdkOptions } from '../common/SdkOptions';
 
-export default function (ilcConfigRoot, router, appErrorHandlerFactory, bundleLoader) {
+export default function (ilcConfigRoot, router, appErrorHandlerFactory, bundleLoader, transitionManager) {
     const asyncBootUp = new AsyncBootUp();
     const registryConf = ilcConfigRoot.getConfig();
 
@@ -99,7 +99,7 @@ export default function (ilcConfigRoot, router, appErrorHandlerFactory, bundleLo
 
                 lifecycleMethods = await Promise.all(waitTill).then(([spaCallbacks, wrapperSpaCallbacks]) => {
                     if (wrapperConf !== null) {
-                        const wrapper = new WrapApp(wrapperConf, overrides.wrapperPropsOverride);
+                        const wrapper = new WrapApp(wrapperConf, overrides.wrapperPropsOverride, transitionManager);
 
                         spaCallbacks = wrapper.wrapWith(spaCallbacks, wrapperSpaCallbacks);
                     }


### PR DESCRIPTION
Doubled TransitionManager led to multiple events about page completion which led to a different non-trivial bugs. TransitionManager is now possible to create multiple times, but only when previous instance removes event subscriptions.