### PR TITLE
fix(WebpackConfig): Prevent error class names discarding

### DIFF
--- a/ilc/build/webpack.js
+++ b/ilc/build/webpack.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 const fs = require('fs');
 const path = require('path');
+const TerserPlugin = require('terser-webpack-plugin');
 const WrapperPlugin = require('wrapper-webpack-plugin');
 const {ResolveIlcDefaultPluginsWebpackPlugin} = require('ilc-plugins-sdk/webpack');
 
@@ -11,6 +12,18 @@ module.exports = {
         path: path.resolve(__dirname, '../public'),
     },
     mode: 'production',
+    optimization: {
+        minimizer: [
+          new TerserPlugin({
+            cache: true,
+            parallel: true,
+            sourceMap: true,
+            terserOptions: {
+              keep_classnames: /.*(Error|error)$/,
+            },
+          }),
+        ],
+    },
     module: {
         rules: [
             { parser: { System: false } },

--- a/ilc/package-lock.json
+++ b/ilc/package-lock.json
@@ -70,6 +70,7 @@
         "rimraf": "^3.0.2",
         "sinon": "^8.1.1",
         "supertest": "^4.0.2",
+        "terser-webpack-plugin": "^1.4.5",
         "webpack": "^4.44.1",
         "webpack-cli": "^3.3.12",
         "webpack-dev-middleware": "^3.7.2",

--- a/ilc/package.json
+++ b/ilc/package.json
@@ -21,6 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@namecheap/error-extender": "^1.2.0",
+    "@namecheap/tailorx": "^7.0.1",
     "@newrelic/native-metrics": "^8.0.0",
     "agentkeepalive": "^4.2.1",
     "axios": "^0.21.4",
@@ -44,7 +45,6 @@
     "single-spa": "5.6.0",
     "systemjs": "6.10.1",
     "systemjs-css-extra": "^1.0.2",
-    "@namecheap/tailorx": "^7.0.1",
     "url-join": "^4.0.1",
     "uuid": "^3.4.0"
   },
@@ -81,6 +81,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^8.1.1",
     "supertest": "^4.0.2",
+    "terser-webpack-plugin": "^1.4.5",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-middleware": "^3.7.2",


### PR DESCRIPTION
During webpack minimize it discard class names, that makes impossible to use constructor.name 
during [error codes build process](https://github.com/namecheap/ilc/blob/master/ilc/client/errors/BaseError.js#L14). 
Fix keeps only error class names as is.