### PR TITLE
Extend props for wrappers with wrapped apps

### DIFF
--- a/ilc/client/WrapApp.js
+++ b/ilc/client/WrapApp.js
@@ -79,6 +79,7 @@ export default class WrapApp {
         const newProps = Object.assign({}, props);
         newProps.appId = this.#wrapperConf.appId;
         newProps.getCurrentPathProps = () => this.#wrapperConf.props;
+        newProps.getWrappedAppProps = () => this.#wrapperConf.wrappedAppConf?.props;
         newProps.getCurrentBasePath = () => '/';
         newProps.appWrapperData = {
             appId: this.#wrapperConf.appId,

--- a/ilc/client/registerSpaApps.js
+++ b/ilc/client/registerSpaApps.js
@@ -69,6 +69,9 @@ export default function (ilcConfigRoot, router, appErrorHandlerFactory, bundleLo
                     wrapperConf = {
                         ...ilcConfigRoot.getConfigForAppByName(appConf.wrappedWith),
                         appId: makeAppId(appConf.wrappedWith, slotName),
+                        ...{
+                            wrappedAppConf: appConf,
+                        }
                     }
                 }
 

--- a/ilc/server/tailor/request-fragment.js
+++ b/ilc/server/tailor/request-fragment.js
@@ -50,7 +50,8 @@ module.exports = (filterHeaders, processFragmentResponse, logger) => function re
                 baseUrl: wrapperConf.src,
                 appId: wrapperConf.appId,
                 props: wrapperConf.props,
-                ignoreBasePath: true
+                ignoreBasePath: true,
+                wrappedAppProps: attributes.appProps
             });
 
             logger.debug({
@@ -207,7 +208,7 @@ module.exports = (filterHeaders, processFragmentResponse, logger) => function re
     });
 }
 
-function makeFragmentUrl({route, baseUrl, appId, props, ignoreBasePath = false, sdkOptions}) {
+function makeFragmentUrl({route, baseUrl, appId, props, ignoreBasePath = false, sdkOptions, wrappedAppProps}) {
     const url = new URL(baseUrl);
 
     const reqProps = {
@@ -224,6 +225,10 @@ function makeFragmentUrl({route, baseUrl, appId, props, ignoreBasePath = false, 
 
     if (sdkOptions) {
         url.searchParams.append('sdk', objectToBase64(sdkOptions));
+    }
+
+    if (wrappedAppProps) {
+        url.searchParams.append('wrappedProps', objectToBase64(wrappedAppProps));
     }
 
     return url.toString();

--- a/ilc/server/tailor/request-fragment.spec.js
+++ b/ilc/server/tailor/request-fragment.spec.js
@@ -115,15 +115,18 @@ describe('request-fragment', () => {
 
         const expectedRouterProps = { basePath: '/', reqUrl: '/wrapper', 'fragmentName': 'wrapper__at__primary' };
         const expectedAppProps = { param1: 'value1' };
+        const wrappedAppProps = { page: 'wrapped' };
 
         const expectedRouterPropsEncoded = Buffer.from(JSON.stringify(expectedRouterProps)).toString('base64');
         const expectedAppPropsEncoded = Buffer.from(JSON.stringify(expectedAppProps)).toString('base64');
+        const expectedWrappedAppPropsEncoded = Buffer.from(JSON.stringify(wrappedAppProps)).toString('base64');
 
         const mockRequestScope = nock('http://apps.test', { reqheaders: { 'accept-encoding': 'gzip, deflate' } })
             .get('/wrapper')
             .query({
                 routerProps: expectedRouterPropsEncoded,
                 appProps: expectedAppPropsEncoded,
+                wrappedProps: expectedWrappedAppPropsEncoded,
             })
             .reply(200);
 
@@ -169,16 +172,19 @@ describe('request-fragment', () => {
         const expectedWrapperRouterProps = { basePath: '/', reqUrl: '/wrapper', 'fragmentName': 'wrapper__at__primary' };
         const expectedWrapperAppProps = { param1: 'value1' };
         const wrapperPropsOverride = { param2: 'value2' };
+        const wrappedAppProps = { page: 'wrapped' };
 
         const expectedWrapperRouterPropsEncoded = Buffer.from(JSON.stringify(expectedWrapperRouterProps)).toString('base64');
         const expectedWrapperAppPropsEncoded = Buffer.from(JSON.stringify(expectedWrapperAppProps)).toString('base64');
         const wrapperPropsOverrideEncoded = Buffer.from(JSON.stringify(wrapperPropsOverride)).toString('base64');
+        const expectedWrappedAppPropsEncoded = Buffer.from(JSON.stringify(wrappedAppProps)).toString('base64');
 
         const mockRequestWrapperScope = nock('http://apps.test', { reqheaders: { 'accept-encoding': 'gzip, deflate' } })
             .get('/wrapper')
             .query({
                 routerProps: expectedWrapperRouterPropsEncoded,
                 appProps: expectedWrapperAppPropsEncoded,
+                wrappedProps: expectedWrappedAppPropsEncoded,
             })
             .reply(210, '', { 'x-props-override': wrapperPropsOverrideEncoded });
 


### PR DESCRIPTION
Wrapper receives the props from wrapped app so it allows to act based on wrapped app context