### PR TITLE
fix: add correct headers to HTTP 500 server side ILC handling in both…

### DIFF
--- a/ilc/server/errorHandler/ErrorHandler.js
+++ b/ilc/server/errorHandler/ErrorHandler.js
@@ -79,9 +79,7 @@ module.exports = class ErrorHandler {
             let data = await this.#registryService.getTemplate('500', { locale, forDomain: currentDomain });
             data = data.data.content.replace('%ERRORID%', `Error ID: ${errorId}`);
 
-            nres.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-            nres.setHeader('Pragma', 'no-cache');
-            nres.statusCode = 500;
+            this.#ensureInternalErrorHeaders(nres);
             nres.write(data);
             nres.end();
         } catch (causeErr) {
@@ -97,8 +95,15 @@ module.exports = class ErrorHandler {
         }
     };
 
-    #writeStaticError(nres) {
+    #ensureInternalErrorHeaders(nres) {
+        nres.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        nres.setHeader('Pragma', 'no-cache');
+        nres.setHeader('Content-Type', 'text/html; charset=utf-8');
         nres.statusCode = 500;
+    }
+
+    #writeStaticError(nres) {
+        this.#ensureInternalErrorHeaders(nres);
         let content = this.#readStaticErrorPage(defaultErrorPage);
 
         nres.write(content);

--- a/ilc/server/errorHandler/ErrorHandler.spec.js
+++ b/ilc/server/errorHandler/ErrorHandler.spec.js
@@ -61,6 +61,7 @@ describe('ErrorHandler', () => {
 
         chai.expect(response.header['cache-control']).to.be.eql('no-cache, no-store, must-revalidate');
         chai.expect(response.header['pragma']).to.be.eql('no-cache');
+        chai.expect(response.header['content-type']).to.be.eql('text/html; charset=utf-8');
         chai.expect(response.text).to.be.eql(
             '<html><head></head>' +
                 '<body>' +
@@ -82,6 +83,7 @@ describe('ErrorHandler', () => {
         const response = await server.get('/_ilc/500').expect(500);
 
         chai.expect(response.text).to.be.eql(defaultErrorPage);
+        chai.expect(response.headers['content-type']).to.be.eql('text/html; charset=utf-8');
     });
 
     describe('when static error page config is specified', () => {


### PR DESCRIPTION
… when error page is overridden in ILC registry template and when ILC default error page is shown.