### PR TITLE
Feat/add cache wrapper

### DIFF
--- a/ilc/client/registry/Registry.js
+++ b/ilc/client/registry/Registry.js
@@ -3,8 +3,8 @@ import errors from './errors';
 export default class Registry {
     errors = errors;
 
-    constructor(wrapWithCache) {
-        this.getTemplate = wrapWithCache(this.#getTemplate, {
+    constructor(cacheWrapper) {
+        this.getTemplate = cacheWrapper.wrap(this.#getTemplate, {
             cacheForSeconds: 3600,
             name: 'registry_getTemplate',
         });

--- a/ilc/client/registry/factory.js
+++ b/ilc/client/registry/factory.js
@@ -1,5 +1,5 @@
 import Registry from './Registry';
-import wrapWithCache from '../../common/wrapWithCache';
+import CacheWrapper from '../../common/CacheWrapper';
 import * as localStorage from '../../common/localStorage';
 
-export default new Registry(wrapWithCache(localStorage, console));
+export default new Registry(new CacheWrapper(localStorage, console));

--- a/ilc/common/CacheWrapper.js
+++ b/ilc/common/CacheWrapper.js
@@ -41,7 +41,7 @@ class CacheWrapper {
 
         return (...args) => {
             const now = this.#nowInSec();
-            const hash = this.createHash(memoName + JSON.stringify(args));
+            const hash = this.createHash(`${memoName}${cacheForSeconds}${JSON.stringify(args)}`);
 
             const logInfo = {
                 now,

--- a/ilc/common/CacheWrapper.js
+++ b/ilc/common/CacheWrapper.js
@@ -30,6 +30,15 @@ class CacheWrapper {
         return `[ILC Cache]: ${str}`;
     }
 
+    #getRequestId() {
+        if (this.context) {
+            const contextStore = this.context.getStore();
+            return contextStore?.get('reqId');
+        }
+
+        return undefined;
+    }
+
     wrap(fn, cacheParams) {
         const { name: memoName, cacheForSeconds = 60 } = cacheParams;
 
@@ -47,7 +56,7 @@ class CacheWrapper {
                 now,
                 hash,
                 memoName,
-                id: this.context && this.context.get('reqId'),
+                id: this.#getRequestId(),
             };
 
             const cache = this.#getCache(hash);

--- a/ilc/server/registry/factory.js
+++ b/ilc/server/registry/factory.js
@@ -6,8 +6,4 @@ const reportingPluginManager = require('../plugins/reportingPlugin');
 const { context } = require('../context/context');
 const logger = reportingPluginManager.getLogger();
 
-module.exports = new Registry(
-    config.get('registry.address'),
-    new CacheWrapper(localStorage, logger, context.getStore()),
-    logger,
-);
+module.exports = new Registry(config.get('registry.address'), new CacheWrapper(localStorage, logger, context), logger);

--- a/ilc/server/registry/factory.js
+++ b/ilc/server/registry/factory.js
@@ -1,9 +1,13 @@
 const config = require('config');
 const localStorage = require('../../common/localStorage');
 const Registry = require('./Registry');
-const wrapFetchWithCache = require('../../common/wrapWithCache');
+const CacheWrapper = require('../../common/CacheWrapper');
 const reportingPluginManager = require('../plugins/reportingPlugin');
-
+const { context } = require('../context/context');
 const logger = reportingPluginManager.getLogger();
 
-module.exports = new Registry(config.get('registry.address'), wrapFetchWithCache(localStorage, logger), logger);
+module.exports = new Registry(
+    config.get('registry.address'),
+    new CacheWrapper(localStorage, logger, context.getStore()),
+    logger,
+);


### PR DESCRIPTION
I rewrote the wrapWithCache function into the CacheWrapper class to store progress promises inside the class. In case there is misuse of the wrap function, it will not result in two parallel requests.