### PR TITLE
feat(ilc/client): expose app configuration to loadApp  method

### DIFF
--- a/e2e/codecept.conf.js
+++ b/e2e/codecept.conf.js
@@ -9,10 +9,9 @@ exports.config = {
     helpers: {
         Puppeteer: {
             url: `http://localhost:8233`,
-            show: process.env.SHOW_UI === 'true',
             windowSize: '1200x900',
             chrome: {
-                headless: 'new',
+                headless: process.env.SHOW_UI === 'true' ? false: 'new',
             },
         },
         MockRequestHelper: {

--- a/ilc/client/BundleLoader.spec.js
+++ b/ilc/client/BundleLoader.spec.js
@@ -160,6 +160,27 @@ describe('BundleLoader', () => {
 
             const callbacks = await loader.loadApp(appName);
             expect(callbacks).to.equal(fnCallbacks);
+            sinon.assert.calledWith(SystemJs.import, appName);
+        });
+        it('should load CssTrackedApp by default', async () => {
+            const loader = new BundleLoader(configRoot, SystemJs, sdkFactoryBuilder);
+            const appName = '@portal/appWithCss';
+
+            SystemJs.import.resolves(fnCallbacks);
+
+            const callbacks = await loader.loadApp(appName);
+            expect(callbacks.__CSS_TRACKED_APP__).to.equal(true);
+
+            sinon.assert.calledWith(SystemJs.import, appName);
+        });
+        it('should load pure app without css if flag set', async () => {
+            const loader = new BundleLoader(configRoot, SystemJs, sdkFactoryBuilder);
+            const appName = '@portal/appWithCss';
+
+            SystemJs.import.resolves(fnCallbacks);
+
+            const callbacks = await loader.loadApp(appName, { injectGlobalCss: false });
+            expect(callbacks.__CSS_TRACKED_APP__).to.equal(undefined);
 
             sinon.assert.calledWith(SystemJs.import, appName);
         });

--- a/ilc/client/Client.js
+++ b/ilc/client/Client.js
@@ -360,7 +360,7 @@ export class Client {
         );
 
         Object.assign(window.ILC, {
-            loadApp: this.#bundleLoader.loadAppWithCss.bind(this.#bundleLoader), // Internal API for Namecheap, not for public use
+            loadApp: this.#bundleLoader.loadApp.bind(this.#bundleLoader),
             navigate: this.#router.navigateToUrl.bind(this.#router),
             onIntlChange: this.#addIntlChangeHandler.bind(this),
             onRouteChange: this.#addRouteChangeHandlerWithDispatch.bind(this),
@@ -371,6 +371,9 @@ export class Client {
             getAllSharedLibNames: () => Promise.resolve(Object.keys(this.#configRoot.getConfig().sharedLibs)),
             getSharedLibConfigByName: (name) => {
                 return Promise.resolve(this.#configRoot.getConfigForSharedLibsByName(name));
+            },
+            getApplicationConfigByName: (name) => {
+                return Promise.resolve(this.#configRoot.getConfigForAppByName(name));
             },
             getSharedLibConfigByNameSync: (name) => {
                 return this.#configRoot.getConfigForSharedLibsByName(name);

--- a/ilc/client/CssTrackedApp.js
+++ b/ilc/client/CssTrackedApp.js
@@ -26,6 +26,7 @@ export class CssTrackedApp {
             mount: this.mount,
             unmount: this.unmount,
             update: this.update,
+            __CSS_TRACKED_APP__: true,
         };
     };
 


### PR DESCRIPTION
Allow to skip css loading in loadApp method based on option `injectGlobalCss`.
`window.ILC.loadApp` loads css via `CssTrackedApp` (backwards compatible).
Add `cssBundle` to the result object of `loadApp` method.