### PR TITLE
fix(ilc/client): observe data-ilc-slot-ready attribute 

### DIFF
--- a/ilc/client/TransitionManager/SlotRenderObserver/SlotRenderObserver.js
+++ b/ilc/client/TransitionManager/SlotRenderObserver/SlotRenderObserver.js
@@ -54,7 +54,11 @@ export class SlotRenderObserver {
             }
         });
 
-        this.#observer.observe(targetNode, { childList: true, subtree: true, attributeFilter: ['style'] });
+        this.#observer.observe(targetNode, {
+            childList: true,
+            subtree: true,
+            attributeFilter: ['style', 'data-ilc-slot-ready'],
+        });
     }
 
     disconnect() {

--- a/ilc/client/TransitionManager/TransitionManager.spec.js
+++ b/ilc/client/TransitionManager/TransitionManager.spec.js
@@ -642,6 +642,34 @@ describe('TransitionManager', () => {
         chai.expect(spinner.getRef()).to.be.null;
     });
 
+    it('should destroy spinner when data attribute is set', async () => {
+        const newBodyApplication = {
+            id: 'new-body-application',
+            class: 'new-body-spa',
+        };
+
+        newBodyApplication.ref = html` <div id="${newBodyApplication.id}" class="${newBodyApplication.class}"></div> `;
+
+        applications.navbar.appendApplication();
+        applications.body.appendApplication();
+
+        handlePageTransition(slots.body.id, slotWillBe.rerendered);
+
+        applications.body.removeApplication();
+        await clock.runAllAsync();
+
+        chai.expect(spinner.getRef()).to.be.not.null;
+
+        slots.body.ref.appendChild(newBodyApplication.ref);
+        await clock.runAllAsync();
+
+        chai.expect(spinner.getRef()).to.be.not.null;
+
+        document.getElementById(newBodyApplication.id).dataset.ilcSlotReady = true;
+        await clock.runAllAsync();
+        chai.expect(spinner.getRef()).to.be.null;
+    });
+
     it('should remove CSS that is marked as non used when all fragments contain visible nodes', async () => {
         const newBodyApplication = {
             id: 'new-body-application',


### PR DESCRIPTION
Watch the `data-ilc-slot-ready` attribute to be able to hide the spinner when this attribute is added dynamically.