### PR TITLE
fix(ilc/server): don't block the cache if promise never resolves

### DIFF
--- a/ilc/build/webpack.test.js
+++ b/ilc/build/webpack.test.js
@@ -20,5 +20,6 @@ const config = {
 };
 
 config.resolve.alias['nock'] = false;
+config.resolve.alias['timers'] = false;
 
 module.exports = config;

--- a/ilc/common/CacheWrapper.js
+++ b/ilc/common/CacheWrapper.js
@@ -1,4 +1,5 @@
 const extendError = require('@namecheap/error-extender');
+const { withTimeout } = require('./utils');
 
 const errors = {};
 errors.CacheWrapperError = extendError('CacheWrapperError', { defaultData: {} });
@@ -104,7 +105,11 @@ class CacheWrapper {
             );
 
             // Start cache renew
-            this.#cacheRenewPromise[hash] = fn(...args)
+            this.#cacheRenewPromise[hash] = withTimeout(
+                fn(...args),
+                cacheForSeconds * 1000,
+                `Cache ${memoName} update timeout ${cacheForSeconds}s`,
+            )
                 .then((data) => {
                     const now = this.#nowInSec();
 

--- a/ilc/common/utils.js
+++ b/ilc/common/utils.js
@@ -62,6 +62,22 @@ function addTrailingSlashToPath(url) {
     return isFullUrl ? parsedUrl.toString() : parsedUrl.pathname.slice(1);
 }
 
+class TimeoutError extends Error {}
+
+/**
+ *
+ * @param {Promise}
+ * @param {number} timeout
+ */
+async function withTimeout(promise, ms, message = 'Promise timeout') {
+    let timeoutId;
+    const timeoutPromise = new Promise((resolve, reject) => {
+        timeoutId = setTimeout(() => reject(new TimeoutError(message)), ms);
+    });
+    const decoratedPromise = promise.finally(() => clearTimeout(timeoutId));
+    return Promise.race([decoratedPromise, timeoutPromise]);
+}
+
 module.exports = {
     appIdToNameAndSlot,
     makeAppId,
@@ -72,4 +88,6 @@ module.exports = {
     removeQueryParams,
     addTrailingSlash,
     addTrailingSlashToPath,
+    withTimeout,
+    TimeoutError,
 };


### PR DESCRIPTION
Based on code analysis and confirmed with unit test there might be a situation when the cache update is stuck and ilc will always return stale cache data.