### PR TITLE
fix(ScrollController): Replace the hashStore node variable with getter

### DIFF
--- a/ilc/client/TransitionManager/ScrollController/ScrollController.js
+++ b/ilc/client/TransitionManager/ScrollController/ScrollController.js
@@ -1,6 +1,5 @@
 export class ScrollController {
     // @todo write e2e tests for hash position restoring
-    #hashStoreNode = document.body;
     #hashStoreAttribute = 'ilcTempStoredHash';
     #lastVisitedUrl = this.location.pathname;
     #shouldScrollToTop = true;
@@ -16,17 +15,22 @@ export class ScrollController {
 
     store() {
         if (this.location.hash) {
-            const node = this.#hashStoreNode;
+            const node = this.#getHashStoreNode();
             const hashValue = this.#getHashValue();
             node.setAttribute(this.#hashStoreAttribute, hashValue);
         }
     }
 
     restore() {
-        const node = this.#hashStoreNode;
+        const node = this.#getHashStoreNode();
         // @todo: looks like it never used so storing is useless
         node.removeAttribute(this.#hashStoreAttribute);
+
         this.#restoreScrollOnNavigation();
+    }
+
+    #getHashStoreNode() {
+        return document.body;
     }
 
     #restoreScrollOnNavigation() {

--- a/ilc/client/TransitionManager/ScrollController/ScrollController.spec.js
+++ b/ilc/client/TransitionManager/ScrollController/ScrollController.spec.js
@@ -51,6 +51,20 @@ describe('ScrollController', () => {
             }
         });
 
+        describe('when the ScrollController is instantiated before the page ready event', () => {
+            let documentBodyStub;
+
+            beforeEach(() => {
+                documentBodyStub = sinon.stub(document, 'body').get(() => undefined);
+                scrollController = new ScrollController();
+                documentBodyStub.restore();
+            });
+
+            it('should not throw error', () => {
+                expect(() => scrollController.restore()).to.not.throw();
+            });
+        });
+
         it('should remove the stored hash attribute from the document body', () => {
             document.body.setAttribute('ilcTempStoredHash', 'testAnchor');
             scrollController.restore();


### PR DESCRIPTION
Replace the hashStore node variable with a getter method to handle the undefined case when instantiating ScrollController before the page ready event.