### PR TITLE
fix(ilc): hard remove CSS link when an embedded application is unmounted

### DIFF
--- a/ilc/client/CssTrackedApp.js
+++ b/ilc/client/CssTrackedApp.js
@@ -47,7 +47,7 @@ export class CssTrackedApp {
                 return newInstance;
             }
 
-            return new CssTrackedApp(newInstance, this.#cssLinkUri, this.#delayCssRemoval).getDecoratedApp();
+            return new CssTrackedApp(newInstance, this.#cssLinkUri, false).getDecoratedApp();
         });
     };
 

--- a/ilc/client/CssTrackedApps.spec.js
+++ b/ilc/client/CssTrackedApps.spec.js
@@ -92,6 +92,29 @@ describe('CssTrackedApp', function () {
                 }),
             );
         });
+
+        it('should remove CSS link after createNew, mount, and unmount', async () => {
+            const returnValue = Math.random();
+            const appOnCreateNew = createOriginalAppFake(Promise.resolve(returnValue));
+            const originalApp = createOriginalAppFake(Promise.resolve(Math.random()));
+            originalApp.createNew = () => Promise.resolve(appOnCreateNew);
+
+            const cssLink = 'data:text/css,<style>div { border: 1px solid blue; }</style>';
+            const cssWrap = new CssTrackedApp(originalApp, cssLink, false).getDecoratedApp();
+
+            const newApp = await cssWrap.createNew();
+
+            await newApp.mount();
+
+            let link = document.querySelector(`link[href="${cssLink}"]`);
+            expect(link).to.not.be.null;
+            expect(link.getAttribute(CssTrackedApp.linkUsagesAttribute)).to.equal('1');
+
+            await newApp.unmount();
+
+            link = document.querySelector(`link[href="${cssLink}"]`);
+            expect(link).to.be.null;
+        });
     });
 
     it('should add counter to css on mount', async () => {


### PR DESCRIPTION
Task: [NPF-2459](https://track.namecheap.net/browse/NPF-2459)

This PR addresses an issue where CSS links injected into the DOM for embedded applications were not being removed properly when the application was unmounted. Previous attempts (see NPF-2229 and NPF-2454) addressed some scenarios, but a specific case remained where CSS was left in the DOM permanently.

Fix
This fix modifies the behavior of the **CssTrackedApp -> createNew** method in ILC to hard remove the CSS links rather than adding **markedForRemovalAttribute** attribute for Embedded application