### PR TITLE
feat(registry): Add endpoint to only change a template's content

### DIFF
--- a/registry/server/templates/interfaces/index.ts
+++ b/registry/server/templates/interfaces/index.ts
@@ -22,3 +22,5 @@ export type UpdateTemplatePayload = Omit<Template, 'name' | 'localizedVersions'>
 
 export type CreateTemplatePayload = Omit<Template, 'localizedVersions'> &
     Partial<Pick<TemplateWithLocalizedVersions, 'localizedVersions'>>;
+
+export type PartialUpdateTemplatePayload = Pick<Template, 'content'>;

--- a/registry/server/templates/routes/index.ts
+++ b/registry/server/templates/routes/index.ts
@@ -8,6 +8,7 @@ import createTemplate from './createTemplate';
 import deleteTemplate from './deleteTemplate';
 import upsertTemplateLocalizedVersion from './upsertTemplateLocalizedVersion';
 import deleteTemplateLocalizedVersion from './deleteTemplateLocalizedVersion';
+import partialUpdateTemplate from './partialUpdateTemplate';
 
 export default (authMw: RequestHandler[]) => {
     const templatesRouter = express.Router();
@@ -17,6 +18,7 @@ export default (authMw: RequestHandler[]) => {
     templatesRouter.get('/:name/rendered', ...getRenderedTemplate);
     templatesRouter.get('/:name', ...getTemplate);
     templatesRouter.put('/:name', authMw, ...updateTemplate);
+    templatesRouter.patch('/:name', authMw, ...partialUpdateTemplate);
     templatesRouter.delete('/:name', authMw, ...deleteTemplate);
     templatesRouter.put('/:name/localized/:locale', authMw, ...upsertTemplateLocalizedVersion);
     templatesRouter.delete('/:name/localized/:locale', authMw, ...deleteTemplateLocalizedVersion);

--- a/registry/server/templates/routes/partialUpdateTemplate.ts
+++ b/registry/server/templates/routes/partialUpdateTemplate.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from 'express';
+import Joi from 'joi';
+
+import validateRequestFactory from '../../common/services/validateRequest';
+import { validateLocalesMiddleware } from '../../middleware/validatelocales';
+import { exhaustiveCheck } from '../../util/exhaustiveCheck';
+import { templatesRepository } from '../services/templatesRepository';
+import { commonTemplate, templateNameSchema } from './validation';
+
+type UpdateTemplateRequestParams = {
+    name: string;
+};
+
+const validateRequestBeforeUpdateTemplate = validateRequestFactory([
+    {
+        schema: Joi.object({
+            name: templateNameSchema.required(),
+        }),
+        selector: 'params',
+    },
+    {
+        schema: Joi.object({
+            content: commonTemplate.content.required(),
+        }),
+        selector: 'body',
+    },
+]);
+
+const partialUpdateTemplate = async (req: Request<UpdateTemplateRequestParams>, res: Response): Promise<void> => {
+    const result = await templatesRepository.partialUpdateTemplate(req.params.name, req.body, req.user);
+
+    switch (result.type) {
+        case 'notFound': {
+            res.status(404).send('Not found');
+            return;
+        }
+        case 'ok': {
+            res.status(200).send(result.template);
+            return;
+        }
+        default: {
+            /* istanbul ignore next */
+            exhaustiveCheck(result);
+        }
+    }
+};
+
+export default [validateRequestBeforeUpdateTemplate, partialUpdateTemplate];

--- a/registry/server/templates/routes/validation.ts
+++ b/registry/server/templates/routes/validation.ts
@@ -6,7 +6,7 @@ import renderTemplate from '../services/renderTemplate';
 
 export const templateNameSchema = Joi.string().min(1).max(50);
 
-const commonTemplate = {
+export const commonTemplate = {
     content: Joi.string()
         .min(1)
         .external(async (value) => {

--- a/registry/server/templates/services/templatesRepository.ts
+++ b/registry/server/templates/services/templatesRepository.ts
@@ -154,7 +154,7 @@ export class TemplatesRepository {
             }
         });
 
-        const savedTemplate = await this.mustReadTemplateWithAllVersions(template.name);
+        const savedTemplate = await this.readTemplateWithAllVersionsOrFail(template.name);
 
         return savedTemplate;
     }
@@ -189,7 +189,7 @@ export class TemplatesRepository {
             },
         );
 
-        const updatedTemplate = await this.mustReadTemplateWithAllVersions(templateName);
+        const updatedTemplate = await this.readTemplateWithAllVersionsOrFail(templateName);
 
         return { type: 'ok', template: updatedTemplate };
     }
@@ -211,7 +211,7 @@ export class TemplatesRepository {
                 .transacting(trx);
         });
 
-        const updatedTemplate = await this.mustReadTemplate(templateName);
+        const updatedTemplate = await this.readTemplateOrFail(templateName);
 
         return { type: 'ok', template: updatedTemplate };
     }
@@ -261,7 +261,7 @@ export class TemplatesRepository {
         return { type: 'ok' };
     }
 
-    private async mustReadTemplate(templateName: string): Promise<VersionedRecord<Template>> {
+    private async readTemplateOrFail(templateName: string): Promise<VersionedRecord<Template>> {
         const [maybeTemplate] = await db
             .selectVersionedRowsFrom<Template>(Tables.Templates, 'name', EntityTypes.templates, [
                 `${Tables.Templates}.*`,
@@ -274,7 +274,7 @@ export class TemplatesRepository {
         return maybeTemplate;
     }
 
-    private async mustReadTemplateWithAllVersions(
+    private async readTemplateWithAllVersionsOrFail(
         templateName: string,
     ): Promise<VersionedRecord<TemplateWithLocalizedVersions>> {
         const maybeTemplate = await this.readTemplateWithAllVersions(templateName);

--- a/registry/tests/templates.spec.ts
+++ b/registry/tests/templates.spec.ts
@@ -618,7 +618,7 @@ describe(`Tests ${example.url}`, () => {
             await req.delete(example.url + example.correctLocalized.name).expect(204);
         });
 
-        it.only('should not allow to pass localizedVersions to the PATCH request', async () => {
+        it('should not allow to pass localizedVersions to the PATCH request', async () => {
             await req.post(example.url).send(example.correct).expect(200);
             await req
                 .patch(example.url + example.correct.name)

--- a/registry/tests/templates.spec.ts
+++ b/registry/tests/templates.spec.ts
@@ -617,6 +617,14 @@ describe(`Tests ${example.url}`, () => {
 
             await req.delete(example.url + example.correctLocalized.name).expect(204);
         });
+
+        it.only('should not allow to pass localizedVersions to the PATCH request', async () => {
+            await req.post(example.url).send(example.correct).expect(200);
+            await req
+                .patch(example.url + example.correct.name)
+                .send(_.omit(example.correctLocalized, 'name'))
+                .expect(422, '"localizedVersions" is not allowed');
+        });
     });
 
     describe('Delete', () => {

--- a/registry/tests/templates.spec.ts
+++ b/registry/tests/templates.spec.ts
@@ -2,10 +2,10 @@ import _ from 'lodash';
 import nock from 'nock';
 import supertest, { type Agent } from 'supertest';
 import app from '../server/app';
-import { expect, getServerAddress } from './common';
 import { SettingKeys } from '../server/settings/interfaces';
-import { withSetting } from './utils/withSetting';
+import { expect, getServerAddress } from './common';
 import { makeFilterQuery } from './utils/makeFilterQuery';
+import { withSetting } from './utils/withSetting';
 
 const example = {
     url: '/api/v1/template/',
@@ -573,6 +573,49 @@ describe(`Tests ${example.url}`, () => {
                     .send(_.omit(example.updated, 'name'))
                     .expect(401);
             });
+        });
+    });
+
+    describe('Partial Update', () => {
+        it("should not partial update any record if record doesn't exist", async () => {
+            const incorrect = { name: 123 };
+            await req
+                .patch(example.url + incorrect.name)
+                .send({ content: example.correct.content })
+                .expect(404, 'Not found');
+        });
+
+        it('should successfully partial update record', async () => {
+            await req.post(example.url).send(example.correct).expect(200);
+
+            const response = await req
+                .patch(example.url + example.correct.name)
+                .send({ content: example.updated.content })
+                .expect(200);
+            expect(response.body).deep.equal({
+                ...example.updated,
+                versionId: response.body.versionId,
+            });
+        });
+
+        it('should not delete localized versions of the template on partial update', async () => {
+            await withSetting(
+                SettingKeys.I18nSupportedLocales,
+                Object.keys(example.correctLocalized.localizedVersions),
+                async () => {
+                    await req.post(example.url).send(example.correctLocalized).expect(200);
+                },
+            );
+
+            await req
+                .patch(example.url + example.correctLocalized.name)
+                .send({ content: example.updated.content })
+                .expect(200);
+
+            const template = await req.get(example.url + example.correctLocalized.name).expect(200);
+            expect(template.body.localizedVersions).deep.equal(example.correctLocalized.localizedVersions);
+
+            await req.delete(example.url + example.correctLocalized.name).expect(204);
         });
     });
 

--- a/registry/tests/templates.spec.ts
+++ b/registry/tests/templates.spec.ts
@@ -577,15 +577,15 @@ describe(`Tests ${example.url}`, () => {
     });
 
     describe('Partial Update', () => {
-        it("should not partial update any record if record doesn't exist", async () => {
-            const incorrect = { name: 123 };
+        it("should not partially update any record if record doesn't exist", async () => {
+            const nonExisting = { name: 123 };
             await req
-                .patch(example.url + incorrect.name)
+                .patch(example.url + nonExisting.name)
                 .send({ content: example.correct.content })
                 .expect(404, 'Not found');
         });
 
-        it('should successfully partial update record', async () => {
+        it('should successfully partially update record', async () => {
             await req.post(example.url).send(example.correct).expect(200);
 
             const response = await req


### PR DESCRIPTION
This PR introduces a new endpoint:

 - `PATCH /api/v1/template/:name`;
   - body: `{ content: string }`

The endpoint allows to update only template's content without deleting its localized versions