### PR TITLE
support more csp directives

### DIFF
--- a/ilc/server/services/CspBuilderService.js
+++ b/ilc/server/services/CspBuilderService.js
@@ -12,6 +12,17 @@ module.exports = class CspBuilderService {
         workerSrc: 'worker-src',
         frameSrc: 'frame-src',
         reportUri: 'report-uri',
+        mediaSrc: 'media-src',
+        childSrc: 'child-src',
+        formAction: 'form-action',
+        manifestSrc: 'manifest-src',
+        objectSrc: 'object-src',
+        scriptSrcAttr: 'script-src-attr',
+        scriptSrcElem: 'script-src-elem',
+        baseUri: 'base-uri',
+        frameAncestors: 'frame-ancestors',
+        sandbox: 'sandbox',
+        upgradeInsecureRequests: 'upgrade-insecure-requests',
     };
 
     #reportingDirectives = [this.#cspDirectiveMap.reportUri];
@@ -55,13 +66,17 @@ module.exports = class CspBuilderService {
             .filter(this.#filterOutReportingDirectives.bind(this))
             .map((cspDirective) => {
                 const cspDirectiveName = this.#cspDirectiveMap[cspDirective];
-                let directiveValueArray = this.#cspJson[cspDirective];
+                const cspDirectiveValue = this.#cspJson[cspDirective];
 
-                if (this.#localEnv) {
-                    directiveValueArray = directiveValueArray.concat(this.#getLocalhosts());
+                if (cspDirectiveValue === true) {
+                    return cspDirectiveName;
                 }
 
-                return `${cspDirectiveName} ${directiveValueArray.join(this.#spaceSeparator)}`;
+                const cspDirectiveValueFinal = this.#localEnv
+                    ? cspDirectiveValue.concat(this.#getLocalhosts())
+                    : cspDirectiveValue;
+
+                return `${cspDirectiveName} ${cspDirectiveValueFinal.join(this.#spaceSeparator)}`;
             })
             .join(this.#semiColonSeparator);
 

--- a/ilc/server/services/CspBuilderService.spec.js
+++ b/ilc/server/services/CspBuilderService.spec.js
@@ -5,8 +5,25 @@ const CspBuilderService = require('./CspBuilderService');
 
 const cspConfigFull = {
     defaultSrc: ['https://test.com'],
+    connectSrc: ['https://connect.com'],
     scriptSrc: ['https://script.com'],
+    styleSrc: ['https://style.com'],
+    fontSrc: ['https://font.com'],
+    imgSrc: ['https://img.com'],
+    workerSrc: ['https://worker.com'],
+    frameSrc: ['https://frame.com'],
     reportUri: '/a/b',
+    mediaSrc: ['https://media.com'],
+    childSrc: ['https://child.com'],
+    formAction: ['https://form.com'],
+    manifestSrc: ['https://manifest.com'],
+    objectSrc: ['https://object.com'],
+    scriptSrcAttr: ['https://scriptattr.com'],
+    scriptSrcElem: ['https://scriptelem.com'],
+    baseUri: ['https://base.com'],
+    frameAncestors: ['https://ancestors.com'],
+    sandbox: ['allow-scripts'],
+    upgradeInsecureRequests: true,
 };
 
 describe('CSP builder', () => {
@@ -23,7 +40,7 @@ describe('CSP builder', () => {
         chai.expect(res.setHeader.calledOnce).to.be.true;
         chai.expect(res.setHeader.getCall(0).args[0]).to.be.eq('content-security-policy-report-only');
         chai.expect(res.setHeader.getCall(0).args[1]).to.be.eq(
-            'default-src https://test.com; script-src https://script.com; report-uri /a/b',
+            'default-src https://test.com; connect-src https://connect.com; script-src https://script.com; style-src https://style.com; font-src https://font.com; img-src https://img.com; worker-src https://worker.com; frame-src https://frame.com; media-src https://media.com; child-src https://child.com; form-action https://form.com; manifest-src https://manifest.com; object-src https://object.com; script-src-attr https://scriptattr.com; script-src-elem https://scriptelem.com; base-uri https://base.com; frame-ancestors https://ancestors.com; sandbox allow-scripts; upgrade-insecure-requests; report-uri /a/b',
         );
     });
 
@@ -40,7 +57,7 @@ describe('CSP builder', () => {
         chai.expect(res.setHeader.calledOnce).to.be.true;
         chai.expect(res.setHeader.getCall(0).args[0]).to.be.eq('content-security-policy');
         chai.expect(res.setHeader.getCall(0).args[1]).to.be.eq(
-            'default-src https://test.com; script-src https://script.com; report-uri /a/b',
+            'default-src https://test.com; connect-src https://connect.com; script-src https://script.com; style-src https://style.com; font-src https://font.com; img-src https://img.com; worker-src https://worker.com; frame-src https://frame.com; media-src https://media.com; child-src https://child.com; form-action https://form.com; manifest-src https://manifest.com; object-src https://object.com; script-src-attr https://scriptattr.com; script-src-elem https://scriptelem.com; base-uri https://base.com; frame-ancestors https://ancestors.com; sandbox allow-scripts; upgrade-insecure-requests; report-uri /a/b',
         );
     });
 
@@ -70,7 +87,7 @@ describe('CSP builder', () => {
         chai.expect(res.setHeader.calledOnce).to.be.true;
         chai.expect(res.setHeader.getCall(0).args[0]).to.be.eq('content-security-policy');
         chai.expect(res.setHeader.getCall(0).args[1]).to.be.eq(
-            'default-src https://test.com https://localhost:* b; script-src https://script.com https://localhost:* b; report-uri /a/b',
+            'default-src https://test.com https://localhost:* b; connect-src https://connect.com https://localhost:* b; script-src https://script.com https://localhost:* b; style-src https://style.com https://localhost:* b; font-src https://font.com https://localhost:* b; img-src https://img.com https://localhost:* b; worker-src https://worker.com https://localhost:* b; frame-src https://frame.com https://localhost:* b; media-src https://media.com https://localhost:* b; child-src https://child.com https://localhost:* b; form-action https://form.com https://localhost:* b; manifest-src https://manifest.com https://localhost:* b; object-src https://object.com https://localhost:* b; script-src-attr https://scriptattr.com https://localhost:* b; script-src-elem https://scriptelem.com https://localhost:* b; base-uri https://base.com https://localhost:* b; frame-ancestors https://ancestors.com https://localhost:* b; sandbox allow-scripts https://localhost:* b; upgrade-insecure-requests; report-uri /a/b',
         );
     });
 });

--- a/registry/server/settings/interfaces/cspSchema.ts
+++ b/registry/server/settings/interfaces/cspSchema.ts
@@ -11,4 +11,31 @@ export const cspSchema = Joi.object({
     workerSrc: cspSrcValidator,
     frameSrc: cspSrcValidator,
     reportUri: Joi.string().required(),
+    mediaSrc: cspSrcValidator,
+    childSrc: cspSrcValidator,
+    formAction: cspSrcValidator,
+    manifestSrc: cspSrcValidator,
+    objectSrc: cspSrcValidator,
+    scriptSrcAttr: cspSrcValidator,
+    scriptSrcElem: cspSrcValidator,
+    baseUri: cspSrcValidator,
+    frameAncestors: cspSrcValidator,
+    sandbox: Joi.array()
+        .items(
+            Joi.string().valid(
+                'allow-forms',
+                'allow-modals',
+                'allow-orientation-lock',
+                'allow-pointer-lock',
+                'allow-popups',
+                'allow-popups-to-escape-sandbox',
+                'allow-presentation',
+                'allow-same-origin',
+                'allow-scripts',
+                'allow-storage-access-by-user-activation',
+                'allow-top-navigation',
+            ),
+        )
+        .optional(),
+    upgradeInsecureRequests: Joi.boolean().optional(),
 }).allow(null);

--- a/registry/server/settings/interfaces/index.ts
+++ b/registry/server/settings/interfaces/index.ts
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import { cspSchema } from './cspSchema';
+import { joiErrorToResponse } from '../../util/helpers';
 
 export enum SettingKeys {
     BaseUrl = 'baseUrl',
@@ -157,13 +158,13 @@ const valueSchema = Joi.alternatives().conditional('key', {
                     try {
                         cspConfig = JSON.parse(value);
                     } catch (error) {
-                        return helpers.error('any.invalid');
+                        return helpers.error('any.custom', { error: { message: 'Invalid JSON' } });
                     }
 
                     const result = cspSchema.validate(cspConfig);
 
                     if (result.error) {
-                        return helpers.error('any.invalid');
+                        return helpers.error('any.custom', { error: { message: joiErrorToResponse(result.error) } });
                     }
 
                     return result.value;


### PR DESCRIPTION
Added support for the media-src, child-src, form-action, manifest-src, object-src, script-src-attr, script-src-elem, base-uri, frame-ancestors, sandbox, and upgrade-insecure-requests CSP directives.