### PR TITLE
chore: extend NoBaseTemplateMatchError data to debug not found temapl…

### DIFF
--- a/ilc/common/router/Router.ts
+++ b/ilc/common/router/Router.ts
@@ -93,7 +93,7 @@ export class Router {
 
     validateResultingRoute(route: RouterMatch) {
         if (!route.template) {
-            throw new NoBaseTemplateMatchError();
+            throw new NoBaseTemplateMatchError({ data: { route: route } });
         }
     }
 

--- a/ilc/common/router/errors.ts
+++ b/ilc/common/router/errors.ts
@@ -18,5 +18,6 @@ export const NoBaseTemplateMatchError = extendError('NoBaseTemplateMatchError', 
     defaultData: {
         code: TEMPLATE_NOT_FOUND_CODE,
         presentable: 'Template not found',
+        route: {},
     },
 });


### PR DESCRIPTION
extend NoBaseTemplateMatchError to make possible debug an issue with absent template for routes