### PR TITLE
feat(registry): add domain-specific props support to router_domains

### DIFF
--- a/registry/client/src/routerDomains/Edit.js
+++ b/registry/client/src/routerDomains/Edit.js
@@ -2,30 +2,49 @@ import React from 'react';
 import {
     Create,
     Edit,
-    SimpleForm,
     TextInput,
     required,
     TextField,
     ReferenceInput,
     SelectInput,
+    TabbedForm,
+    FormTab,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import JsonField from '../JsonField';
 import Title from './Title';
 
 const InputForm = ({ mode = 'edit', ...props }) => {
     return (
-        <SimpleForm {...props}>
-            {mode === 'edit'
-                ? <TextField source="id" />
-                : null}
+        <TabbedForm {...props}>
+            <FormTab label="General">
+                {mode === 'edit' ? <TextField source="id" /> : null}
 
-            <TextInput source="domainName" fullWidth validate={required()} />
-            <ReferenceInput reference="template"
-                source="template500"
-                label="Template of 500 error"
-                validate={required()}>
-                <SelectInput resettable optionText="name" />
-            </ReferenceInput>
-        </SimpleForm>
+                <TextInput source="domainName" fullWidth validate={required()} />
+                <ReferenceInput
+                    reference="template"
+                    source="template500"
+                    label="Template of 500 error"
+                    validate={required()}
+                >
+                    <SelectInput resettable optionText="name" />
+                </ReferenceInput>
+            </FormTab>
+
+            <FormTab label="Domain Props">
+                <JsonField
+                    source="props"
+                    label="Client Props"
+                    helperText="Properties available in browser (e.g., API URLs, CDN URLs, feature flags)"
+                    fullWidth
+                />
+                <JsonField
+                    source="ssrProps"
+                    label="SSR Props"
+                    helperText="Server-side only properties (e.g., internal API URLs, secrets)"
+                    fullWidth
+                />
+            </FormTab>
+        </TabbedForm>
     );
 };
 
@@ -34,6 +53,7 @@ export const MyEdit = ({ permissions, ...props }) => (
         <InputForm mode="edit" />
     </Edit>
 );
+
 export const MyCreate = ({ permissions, ...props }) => {
     return (
         <Create {...props}>

--- a/registry/client/src/routerDomains/Show.js
+++ b/registry/client/src/routerDomains/Show.js
@@ -1,12 +1,8 @@
 import React from 'react';
-import {
-    Show,
-    SimpleShowLayout,
-    TextField,
-    ReferenceField,
-} from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { Show, SimpleShowLayout, TextField, ReferenceField } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import Title from './Title';
 import { ShowTopToolbar } from '../components';
+import { JsonFieldShow } from '../JsonField';
 
 export default ({ permissions, hasList, hasEdit, hasShow, hasCreate, ...props }) => {
     return (
@@ -15,11 +11,14 @@ export default ({ permissions, hasList, hasEdit, hasShow, hasCreate, ...props })
                 <TextField source="id" />
 
                 <TextField source="domainName" />
-                <ReferenceField reference="template"
-                    source="template500"
-                    label="Template of 500 error">
+                <ReferenceField reference="template" source="template500" label="Template of 500 error">
                     <TextField source="name" />
                 </ReferenceField>
+                <JsonFieldShow source="props" label="Properties that will be passed to applications" />
+                <JsonFieldShow
+                    source="ssrProps"
+                    label="Properties that will be added to main props at SSR request, allow to override certain values"
+                />
             </SimpleShowLayout>
         </Show>
     );

--- a/registry/client/src/routerDomains/dataTransform.js
+++ b/registry/client/src/routerDomains/dataTransform.js
@@ -13,12 +13,10 @@ export function transformSet(entity, operation) {
     if (operation === setOperations.update) {
         delete entity.id;
     }
-    console.log(entity);
     if (entity.props && typeof entity.props === 'string') {
         entity.props = JSON.parse(entity.props);
     }
     if (entity.ssrProps && typeof entity.ssrProps === 'string') {
         entity.ssrProps = JSON.parse(entity.ssrProps);
     }
-    console.log(entity);
 }

--- a/registry/client/src/routerDomains/dataTransform.js
+++ b/registry/client/src/routerDomains/dataTransform.js
@@ -1,11 +1,24 @@
-import { setOperations } from "../dataProvider";
+import { setOperations } from '../dataProvider';
 
 export function transformGet(entity) {
-
+    if (entity.props) {
+        entity.props = JSON.stringify(entity.props);
+    }
+    if (entity.ssrProps) {
+        entity.ssrProps = JSON.stringify(entity.ssrProps);
+    }
 }
 
 export function transformSet(entity, operation) {
     if (operation === setOperations.update) {
         delete entity.id;
     }
+    console.log(entity);
+    if (entity.props && typeof entity.props === 'string') {
+        entity.props = JSON.parse(entity.props);
+    }
+    if (entity.ssrProps && typeof entity.ssrProps === 'string') {
+        entity.ssrProps = JSON.parse(entity.ssrProps);
+    }
+    console.log(entity);
 }

--- a/registry/server/config/getConfig.ts
+++ b/registry/server/config/getConfig.ts
@@ -39,7 +39,7 @@ export const getConfig: RequestHandler = async (req, res) => {
         dynamicLibs: {},
     };
 
-    data.apps = transformApps(apps, routerDomains, sharedProps);
+    data.apps = transformApps(apps, routerDomains, sharedProps, domainName);
 
     data.templates = templates.map(({ name }) => name);
 

--- a/registry/server/config/transformConfig.ts
+++ b/registry/server/config/transformConfig.ts
@@ -39,7 +39,10 @@ export function transformApps(
     apps: VersionedRecord<App>[],
     routerDomains: RouterDomains[],
     sharedProps: any[],
+    domainName?: string,
 ): Record<string, AppDto> {
+    const currentDomain = domainName ? routerDomains.find((d) => d.domainName === domainName) : null;
+
     return apps.reduce(
         (acc, app) => {
             const getDomainName = (domainId: number) => routerDomains.find((x) => x.id === domainId)?.domainName;
@@ -53,6 +56,14 @@ export function transformApps(
                 ssrProps: parseJSON<TransformedApp['ssrProps']>(app.ssrProps),
                 enforceDomain: app.enforceDomain ? getDomainName(app.enforceDomain) : undefined,
             };
+
+            // Apply domain-specific props
+            if (currentDomain?.props) {
+                jsonParsedApp.props = merge({}, parseJSON(currentDomain.props), jsonParsedApp.props);
+            }
+            if (currentDomain?.ssrProps) {
+                jsonParsedApp.ssrProps = merge({}, parseJSON(currentDomain.ssrProps), jsonParsedApp.ssrProps);
+            }
 
             if (sharedProps.length && app.configSelector !== null) {
                 parseJSON<string[]>(app.configSelector).forEach((configSelectorName) => {

--- a/registry/server/migrations/20250618105344_add_props_to_router_domains.ts
+++ b/registry/server/migrations/20250618105344_add_props_to_router_domains.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.table('router_domains', (table) => {
+        table.json('props');
+        table.json('ssrProps');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.table('router_domains', (table) => {
+        table.dropColumn('props');
+        table.dropColumn('ssrProps');
+    });
+}

--- a/registry/server/routerDomains/interfaces/index.ts
+++ b/registry/server/routerDomains/interfaces/index.ts
@@ -8,6 +8,8 @@ export default interface RouterDomains {
     id: number;
     domainName: string;
     template500?: string;
+    props?: Record<string, any> | null;
+    ssrProps?: Record<string, any> | null;
 }
 
 export const routerDomainIdSchema = Joi.string().trim().required();
@@ -18,13 +20,15 @@ const commonRouterDomainsSchema = {
         .min(1)
         .required()
         .external((value) => {
-            if (value.match(/^(localhost|127\.0\.0\.1)(:\d{5})?$/) || isValidDomain(value)) {
+            if (value.match(/^(localhost|127\.0\.0\.1)(:\d{1,5})?$/) || isValidDomain(value)) {
                 return;
             }
 
             throw getJoiErr('domainName', 'Specified "domainName" is not valid.', value);
         }),
     template500: templateNameSchema.required(),
+    props: Joi.object().allow(null).default(null),
+    ssrProps: Joi.object().allow(null).default(null),
     versionId: Joi.string().strip(),
 };
 

--- a/registry/server/routerDomains/routes/createRouterDomains.ts
+++ b/registry/server/routerDomains/routes/createRouterDomains.ts
@@ -6,6 +6,7 @@ import preProcessResponse from '../../common/services/preProcessResponse';
 import RouterDomains, { routerDomainsSchema } from '../interfaces';
 import { extractInsertedId } from '../../util/db';
 import { defined } from '../../util/helpers';
+import { stringifyJSON } from '../../common/services/json';
 
 const validateRequest = validateRequestFactory([
     {
@@ -17,7 +18,9 @@ const validateRequest = validateRequestFactory([
 const createRouterDomains = async (req: Request, res: Response): Promise<void> => {
     let routerDomainId: number | undefined;
     await db.versioning(req.user, { type: 'router_domains' }, async (trx) => {
-        const result = await db('router_domains').insert(req.body, 'id').transacting(trx);
+        const result = await db('router_domains')
+            .insert(stringifyJSON(['props', 'ssrProps'], req.body), 'id')
+            .transacting(trx);
         routerDomainId = extractInsertedId(result);
         return routerDomainId;
     });

--- a/registry/server/routerDomains/routes/updateRouterDomains.ts
+++ b/registry/server/routerDomains/routes/updateRouterDomains.ts
@@ -36,7 +36,10 @@ const updateRouterDomains = async (req: Request<RequestParams>, res: Response): 
     }
 
     await db.versioning(req.user, { type: 'router_domains', id: routerDomainId }, async (trx) => {
-        await db('router_domains').where({ id: routerDomainId }).update(req.body).transacting(trx);
+        await db('router_domains')
+            .where({ id: routerDomainId })
+            .update(stringifyJSON(['props', 'ssrProps'], req.body))
+            .transacting(trx);
     });
 
     const [updatedRouterDomains] = await db.select().from<RouterDomains>('router_domains').where('id', routerDomainId);


### PR DESCRIPTION
- Add props and ssrProps fields to router_domains table
- Update transformConfig to apply domain props to all apps
- Update UI to allow editing domain props
- Main goal - resolve CORS issues for multi-domain deployments