### PR TITLE
fix handling same route pattern for "*" path

### DIFF
--- a/ilc/server/tailor/merge-configs.spec.ts
+++ b/ilc/server/tailor/merge-configs.spec.ts
@@ -632,5 +632,151 @@ describe('merge configs', () => {
 
             expect(mergeConfigs(registryConfig, overrideConfig, 7)).to.be.eql(mergedConfig);
         });
+        it('should handle routes with same pattern but different orderPos including wildcard routes', () => {
+            const registryConfigWithWildcardRoutes: TransformedRegistryConfig = {
+                ...registryConfig,
+                routes: [
+                    {
+                        routeId: 1,
+                        route: '*',
+                        next: true,
+                        orderPos: -99,
+                        template: 'commonTemplate',
+                        slots: {
+                            base: {
+                                appName: '@portal/base',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                        meta: {},
+                        versionId: 'v1.0.0',
+                    },
+                    {
+                        routeId: 2,
+                        route: '/const',
+                        next: false,
+                        orderPos: 1,
+                        slots: {
+                            const: {
+                                appName: apps['@portal/const'].name,
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                        meta: {},
+                        versionId: 'v1.0.1',
+                    },
+                ],
+            };
+
+            const overrideConfig = {
+                routes: [
+                    {
+                        route: '*',
+                        orderPos: 1,
+                        slots: {
+                            override1: {
+                                appName: '@portal/override1',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                    },
+                    {
+                        route: '*',
+                        orderPos: 2,
+                        slots: {
+                            override2: {
+                                appName: '@portal/override2',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                    },
+                    {
+                        route: '/const',
+                        orderPos: 100,
+                        slots: {
+                            overrideConst: {
+                                appName: '@portal/override-const',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                    },
+                ],
+            };
+
+            const mergedConfig = {
+                apps,
+                specialRoutes,
+                sharedLibs,
+                settings: {} as any,
+                dynamicLibs: {} as any,
+                routes: [
+                    {
+                        routeId: 1,
+                        route: '*',
+                        next: true,
+                        orderPos: -99,
+                        template: 'commonTemplate',
+                        slots: {
+                            base: {
+                                appName: '@portal/base',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                        meta: {},
+                        versionId: 'v1.0.0',
+                    },
+                    {
+                        route: '*',
+                        orderPos: 1,
+                        slots: {
+                            override1: {
+                                appName: '@portal/override1',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                    },
+                    {
+                        route: '*',
+                        orderPos: 2,
+                        slots: {
+                            override2: {
+                                appName: '@portal/override2',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                    },
+                    {
+                        routeId: 2,
+                        route: '/const',
+                        next: false,
+                        orderPos: 100,
+                        slots: {
+                            const: {
+                                appName: apps['@portal/const'].name,
+                                kind: null,
+                                props: {},
+                            },
+                            overrideConst: {
+                                appName: '@portal/override-const',
+                                kind: null,
+                                props: {},
+                            },
+                        } as Record<string, any>,
+                        meta: {},
+                        versionId: 'v1.0.1',
+                    },
+                ],
+            };
+
+            expect(mergeConfigs(registryConfigWithWildcardRoutes, overrideConfig)).to.be.eql(mergedConfig);
+        });
     });
 });

--- a/ilc/server/tailor/merge-configs.ts
+++ b/ilc/server/tailor/merge-configs.ts
@@ -31,7 +31,9 @@ export function mergeConfigs(
     const isSameRoute = (overrideRoute: OverrideRoute, originalRoute: TransformedRoute) =>
         overrideRoute.routeId
             ? overrideRoute.routeId === originalRoute.routeId
-            : overrideRoute.route === originalRoute.route;
+            : overrideRoute.route === '*'
+              ? overrideRoute.route === originalRoute.route && overrideRoute.orderPos === originalRoute.orderPos
+              : overrideRoute.route === originalRoute.route;
 
     const isSameDomainRoute = (route: OverrideRoute) => route.domainId === domainId;
 


### PR DESCRIPTION
**Problem**
The current route merging logic was incorrectly treating wildcard routes (*) with different orderPos values as the same route, causing them to be merged instead of being preserved as separate routes. This prevented developers from creating multiple wildcard routes with different ordering priorities.

**Current Behavior**
Routes are considered "the same" and will be merged if:

They have matching routeId values, OR
They have matching route patterns (regardless of orderPos)
This means:

A wildcard route * with orderPos: -99 would merge with another * route having orderPos: 1
Non-wildcard routes like /users with orderPos: 10 would merge with /users having orderPos: 50
Routes are matched purely on pattern, ignoring positioning

**New Behavior**
Routes are considered "the same" and will be merged if:

They have matching routeId values, OR
For wildcard routes (*): They have matching route pattern AND matching orderPos values
For all other routes: They have matching route patterns (orderPos ignored)

**This means:**

Wildcard route * with orderPos: -99 will NOT merge with * having orderPos: 1 (treated as separate routes)
Non-wildcard routes like /users with orderPos: 10 will still merge with /users having orderPos: 50
Wildcard routes now require exact orderPos matching for merging

**Use Case Enabled**
This change enables developers to create multiple wildcard routes with different priorities:

Scenario: Base wildcard route for common layout, plus specific wildcard routes for different sections

Original: * (orderPos: -99) provides base template and common slots
Override: * (orderPos: 1) adds header-specific functionality
Override: * (orderPos: 2) adds footer-specific functionality
Result: Three separate wildcard routes that work together in the routing cascade, instead of being incorrectly merged into one.

Impact Analysis
✅ Preserves existing behavior for non-wildcard routes
✅ Preserves existing behavior for routes with routeId
✅ Enables new functionality for wildcard routes with different orderPos
