### PR TITLE
feat(registry): change configuration approach of protectedSettings

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,4 +3,7 @@
  */
 module.exports = {
     extends: ['@commitlint/config-conventional'],
+    rules: {
+        'body-max-line-length': [2, 'always', 200],
+    },
 };

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -16,7 +16,6 @@ RUN cd ./client && npm ci
 
 ADD ./ /codebase
 
-ENV ILC_REGISTRY_ADMIN_PROTECTED_SETTINGS='<%PROTECTED_SETTING%>'
 RUN npm run build
 
 ENTRYPOINT ["sh", "./scripts/docker-entrypoint.sh"]

--- a/registry/client/README.md
+++ b/registry/client/README.md
@@ -29,7 +29,7 @@ Example:
 
 ```bash
 export ILC_REGISTRY_ADMIN_PROTECTED_SETTINGS="setting1,setting2"
-npm run build[:watch]
+npm run dev
 ```
 
 Or override it inside your custom custom Dockerfile:

--- a/registry/client/src/settings/dataTransform.js
+++ b/registry/client/src/settings/dataTransform.js
@@ -8,8 +8,6 @@ export const types = {
     json: 'json',
 };
 
-const PROTECTED_SETTINGS = process.env.PROTECTED_SETTINGS?.split(',') ?? [];
-
 export function transformGet(setting) {
     setting.id = setting.key;
 
@@ -29,7 +27,6 @@ export function transformGet(setting) {
     }
 
     setting.domainId = setting.domainId || null;
-    setting.protected = PROTECTED_SETTINGS.includes(setting.key);
 }
 
 export function transformSet(setting) {

--- a/registry/client/webpack.config.js
+++ b/registry/client/webpack.config.js
@@ -1,4 +1,3 @@
-const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -32,9 +31,6 @@ module.exports = {
         new MiniCssExtractPlugin(),
         new HtmlWebpackPlugin({
             template: './src/index.html',
-        }),
-        new webpack.DefinePlugin({
-            'process.env.PROTECTED_SETTINGS': JSON.stringify(process.env.ILC_REGISTRY_ADMIN_PROTECTED_SETTINGS || ''),
         }),
     ].concat(process.env.NODE_ENV === 'development' ? [new BundleAnalyzerPlugin({ openAnalyzer: false })] : []),
     resolve: {

--- a/registry/config/custom-environment-variables.ts
+++ b/registry/config/custom-environment-variables.ts
@@ -29,4 +29,5 @@ export default {
             baseUrl: 'ILC_REGISTRY_BASE_URL',
         },
     },
+    protectedSettings: 'ILC_REGISTRY_ADMIN_PROTECTED_SETTINGS',
 };

--- a/registry/config/default.ts
+++ b/registry/config/default.ts
@@ -38,5 +38,6 @@ module.exports = {
             baseUrl: null,
         },
     },
+    protectedSettings: '',
     salt: 'default_test_salt',
 };

--- a/registry/config/mysql-test.ts
+++ b/registry/config/mysql-test.ts
@@ -8,4 +8,5 @@ module.exports = {
             password: 'pwd',
         },
     },
+    protectedSettings: 'cspConfig,baseUrl',
 };

--- a/registry/config/postgres-test.ts
+++ b/registry/config/postgres-test.ts
@@ -8,4 +8,5 @@ module.exports = {
             password: 'pwd',
         },
     },
+    protectedSettings: 'cspConfig,baseUrl',
 };

--- a/registry/config/sqlite-test.ts
+++ b/registry/config/sqlite-test.ts
@@ -7,4 +7,5 @@ module.exports = {
         },
         useNullAsDefault: true,
     },
+    protectedSettings: 'cspConfig,baseUrl',
 };

--- a/registry/config/test.ts
+++ b/registry/config/test.ts
@@ -1,0 +1,3 @@
+module.exports = {
+    protectedSettings: 'cspConfig,baseUrl',
+};

--- a/registry/scripts/docker-entrypoint.sh
+++ b/registry/scripts/docker-entrypoint.sh
@@ -7,6 +7,4 @@ if [ "$DB_SEED" = 'true' ] && [ ! -f .seed ]; then
   touch .seed
 fi
 
-sed -i "s/<%PROTECTED_SETTING%>/$ILC_REGISTRY_ADMIN_PROTECTED_SETTINGS/g" /codebase/client/dist/*.js
-
 exec "$@"

--- a/registry/server/settings/interfaces/index.ts
+++ b/registry/server/settings/interfaces/index.ts
@@ -96,6 +96,7 @@ export type SettingParsed = Omit<SettingRaw, 'value' | 'default' | 'meta'> & {
     value?: SettingValue;
     default?: SettingValue;
     meta: SettingMeta;
+    protected?: boolean;
 };
 
 export const keySchema = Joi.string()

--- a/registry/server/settings/services/SettingsService.ts
+++ b/registry/server/settings/services/SettingsService.ts
@@ -1,3 +1,4 @@
+import config from 'config';
 import { User } from '../../../typings/User';
 import { JSONValue, isNumeric, safeParseJSON } from '../../common/services/json';
 import db from '../../db';
@@ -23,6 +24,8 @@ type GetOptions = {
 
 export class SettingsService {
     private changesTracking: any = {};
+
+    private protectedSettings = config.get<string>('protectedSettings').split(',');
 
     //TODO: implement cache
     //private cache: any = {};
@@ -287,8 +290,8 @@ export class SettingsService {
         return true;
     }
 
-    private parseSetting(settings: SettingRaw): SettingParsed {
-        const parsedSetting: SettingParsed = safeParseJSON<SettingParsed>(settings, this.isSettingTypeGuard);
+    private parseSetting(setting: SettingRaw): SettingParsed {
+        const parsedSetting: SettingParsed = safeParseJSON<SettingParsed>(setting, this.isSettingTypeGuard);
 
         if (
             parsedSetting.value === undefined ||
@@ -311,6 +314,8 @@ export class SettingsService {
             delete parsedSetting.value;
             delete parsedSetting.default;
         }
+
+        parsedSetting.protected = this.protectedSettings.includes(setting.key) ? true : undefined;
 
         return parsedSetting;
     }

--- a/registry/tests/settings.spec.ts
+++ b/registry/tests/settings.spec.ts
@@ -115,6 +115,7 @@ describe(url, () => {
                 meta: {
                     type: SettingTypes.Url,
                 },
+                protected: true,
             });
             chai.expect(response.body).to.deep.include({
                 key: SettingKeys.AmdDefineCompatibilityMode,
@@ -280,6 +281,7 @@ describe(url, () => {
                     domainValue: JSON.parse(cspValue),
                     scope: Scope.Ilc,
                     secret: false,
+                    protected: true,
                     meta: {
                         type: SettingTypes.JSON,
                     },
@@ -306,6 +308,7 @@ describe(url, () => {
                     meta: {
                         type: SettingTypes.JSON,
                     },
+                    protected: true,
                 };
 
                 chai.expect(response.body).to.deep.include(defaultCsp);
@@ -336,12 +339,15 @@ describe(url, () => {
                     meta: {
                         type: SettingTypes.JSON,
                     },
+                    protected: true,
                 });
             } finally {
                 await deleteConfigRequest(id).expect(204);
                 await domainHelper.destroy();
             }
         });
+
+        it('it should mark specific settings as protected', async () => {});
     });
 
     describe('when a user tries to update information', () => {
@@ -364,6 +370,7 @@ describe(url, () => {
                     meta: {
                         type: SettingTypes.Url,
                     },
+                    protected: true,
                 });
             } finally {
                 await req
@@ -668,6 +675,7 @@ describe(url, () => {
                     domainId: domainHelper.getResponse().id,
                     id: response.body.id,
                     secret: false,
+                    protected: true,
                 });
             } finally {
                 await domainHelper.destroy();
@@ -708,6 +716,7 @@ describe(url, () => {
                     domainId: domainHelper.getResponse().id,
                     id: configResponse.body.id, // id not changed
                     secret: false,
+                    protected: true,
                 });
             } finally {
                 await deleteConfigRequest(id);


### PR DESCRIPTION
mutating JS bundle in the Docker runtime may not be possible in case of read-only filesystem; thus moving env variable to the server and adding "protected" property on the API level