### PR TITLE
Feat/experiment enrollment

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -6,9 +6,9 @@ render the branch they were given — no flicker, no client-side flip.
 
 This page is for two audiences:
 
--   **Product / experiment owners** — start with _"What you can and can't do in Phase 1"_.
--   **Developers** — the rest walks through defining an experiment, reading the variant,
-    and how the pieces fit.
+- **Product / experiment owners** — start with _"What you can and can't do in Phase 1"_.
+- **Developers** — the rest walks through defining an experiment, reading the variant,
+  and how the pieces fit.
 
 ---
 
@@ -16,36 +16,36 @@ This page is for two audiences:
 
 **You can:**
 
--   **Run an A/B or multi-variant test** (any number of variants, each with a traffic
-    weight) that spans one page or several microfrontends on that page — every app in the
-    request sees the **same** assignment, so a test can cover a whole funnel step.
--   **Split traffic by percentage** (e.g. 50/50, or 34/33/33). Assignment is **random but
-    stable**: a given visitor is put in a bucket once and **keeps that variant** for the
-    life of the experiment (up to a year), across reloads and navigation.
--   **Turn everything off instantly** with a global kill-switch (no deploy) — e.g. during
-    an incident. Everyone reverts to the baseline.
--   **Trust it not to break the site** — if anything about the experiment layer goes wrong,
-    the visitor simply sees the baseline; the page still renders.
--   **Add / pause / reweight experiments via configuration** (see below) rather than a code
-    change to the assignment logic.
+- **Run an A/B or multi-variant test** (any number of variants, each with a traffic
+  weight) that spans one page or several microfrontends on that page — every app in the
+  request sees the **same** assignment, so a test can cover a whole funnel step.
+- **Split traffic by percentage** (e.g. 50/50, or 34/33/33). Assignment is **random but
+  stable**: a given visitor is put in a bucket once and **keeps that variant** for the
+  life of the experiment (up to a year), across reloads and navigation.
+- **Turn everything off instantly** with a global kill-switch (no deploy) — e.g. during
+  an incident. Everyone reverts to the baseline.
+- **Trust it not to break the site** — if anything about the experiment layer goes wrong,
+  the visitor simply sees the baseline; the page still renders.
+- **Add / pause / reweight experiments via configuration** (see below) rather than a code
+  change to the assignment logic.
 
 **You can't (yet) — deferred to later phases:**
 
--   **Reach visitors who don't reload.** A newly launched or changed experiment reaches a
-    visitor only on their **next full page load**. Long-lived single-page sessions won't
-    pick it up until they reload — there's no live push (polling/streaming) yet. Read
-    results knowing only reloading visitors were exposed.
--   **Target an audience.** Assignment is a random split by visitor. There's no targeting
-    by geography, campaign/UTM, new-vs-returning, logged-in status, or user attributes.
--   **Self-serve from a UI.** Experiments are defined in configuration by an engineer;
-    there is no management dashboard.
--   **Coordinate overlapping experiments.** No mutual-exclusion / conflict rules — if two
-    experiments touch the same surface, that's on the authors to avoid.
--   **Get analytics out of the box.** ILC assigns and delivers the variant; **measuring**
-    it (exposure/conversion events, dashboards) is the consuming app's/BI pipeline's job.
--   **Assume consent handling.** Experiments are not gated on user consent unless a
-    deployment wires that up (see _Consent_). Treat consent as a prerequisite before any
-    production rollout in a regulated market.
+- **Reach visitors who don't reload.** A newly launched or changed experiment reaches a
+  visitor only on their **next full page load**. Long-lived single-page sessions won't
+  pick it up until they reload — there's no live push (polling/streaming) yet. Read
+  results knowing only reloading visitors were exposed.
+- **Target an audience.** Assignment is a random split by visitor. There's no targeting
+  by geography, campaign/UTM, new-vs-returning, logged-in status, or user attributes.
+- **Self-serve from a UI.** Experiments are defined in configuration by an engineer;
+  there is no management dashboard.
+- **Coordinate overlapping experiments.** No mutual-exclusion / conflict rules — if two
+  experiments touch the same surface, that's on the authors to avoid.
+- **Get analytics out of the box.** ILC assigns and delivers the variant; **measuring**
+  it (exposure/conversion events, dashboards) is the consuming app's/BI pipeline's job.
+- **Assume consent handling.** Experiments are not gated on user consent unless a
+  deployment wires that up (see _Consent_). Treat consent as a prerequisite before any
+  production rollout in a regulated market.
 
 ---
 
@@ -64,12 +64,12 @@ server router
 ILC's `onRequest` hook is the single server-side point shared by every fragment, which
 makes it the natural place to resolve a variant:
 
--   **No flicker** — the variant is fixed before the first byte of HTML, so SSR'd fragments
-    render the correct branch on first paint.
--   **Cross-fragment consistency** — every fragment in the request gets the same map, so one
-    experiment can span multiple microfrontends.
--   **Fail-safe** — assignment is in-memory, never blocks the request, and on any error the
-    visitor falls back to the baseline.
+- **No flicker** — the variant is fixed before the first byte of HTML, so SSR'd fragments
+  render the correct branch on first paint.
+- **Cross-fragment consistency** — every fragment in the request gets the same map, so one
+  experiment can span multiple microfrontends.
+- **Fail-safe** — assignment is in-memory, never blocks the request, and on any error the
+  visitor falls back to the baseline.
 
 An app reads its variant from `appProps.experiments`. Because the value is resolved once
 on the server and forwarded to the fragment for both its SSR render and its client
@@ -100,16 +100,28 @@ experiments: {
 
 Per-experiment knobs:
 
--   **`variants`** — any number of named variants (not limited to two). `weight` is the
-    percentage of traffic; weights should sum to 100. The **first** variant is the
-    baseline / fallback.
--   **`status`** — `active` assigns variants; `paused` sends everyone to the baseline
-    without deleting the definition.
--   **`consentCategory`** _(optional)_ — gate the experiment behind consent (see _Consent_).
+- **`variants`** — any number of named variants (not limited to two). `weight` is the
+  percentage of traffic; weights should sum to 100. The **first** variant is the
+  baseline / fallback.
+- **`status`** — `active` assigns variants; `paused` sends everyone to the baseline
+  without deleting the definition.
+- **`consentCategory`** _(optional)_ — gate the experiment behind consent (see _Consent_).
+- **`enrollment`** _(optional)_ — gate **first-time enrollment** by request path:
+  `enrollment: { paths: ['/sample-nodejs'] }` recruits new participants only on the
+  listed path prefixes (segment-aligned: `/shop` covers `/shop/cart`, not `/shopping`;
+  `/` is root-exact — homepage only, since "everywhere" is expressed by omitting the
+  field; matched against the raw request path, query excluded). Visitors who never hit
+  an enrollment path get **nothing** — no assignment, no `x-ab-*` cookie, no `ilc-sid`.
+
+    This is **not a route-scoped experiment**: once a visitor is enrolled, the stored
+    assignment is honoured on every route — participation never toggles with navigation.
+    The gate narrows _who joins the population_, not _where the experiment applies_.
+    Route-scoped experiments (a variant turning on/off as the visitor navigates) are
+    intentionally not supported.
 
 `validateRuleset()` reports authoring mistakes (weights ≠ 100, a zero-weight/unreachable
-variant, duplicate names, non-numeric/negative weights, an unknown `status`, or a
-cookie-unsafe id) without ever blocking startup. The ruleset source sits behind a small
+variant, duplicate names, non-numeric/negative weights, an unknown `status`, a
+cookie-unsafe id, or a malformed `enrollment` gate) without ever blocking startup. The ruleset source sits behind a small
 `RulesetProvider` seam (`ruleset.ts`) — today a static config layer, so it can later move
 to a managed experiment service without touching the assignment code.
 
@@ -195,15 +207,15 @@ no-store` whenever it carries an assignment or sets a cookie.
 
 ## Limitations & roadmap
 
--   **No live delivery to open sessions.** New/changed experiments reach a session only on
-    its next full page load; a push mechanism (SSE/polling) is future work.
--   **No audience targeting, no mutual-exclusion, no management UI** — see Phase 1 scope above.
--   **Analytics is the app's responsibility.** ILC assigns and propagates; emitting
-    exposure/conversion events (and any queue/retry) belongs to the consuming app.
--   **No per-variant edge caching.** Experiment responses are `no-store`; a variant-aware
-    cache key would be needed before edge-caching them.
--   **Crawlers are assigned like any visitor.** A deployment that cares should bypass
-    assignment for bots.
+- **No live delivery to open sessions.** New/changed experiments reach a session only on
+  its next full page load; a push mechanism (SSE/polling) is future work.
+- **No audience targeting, no mutual-exclusion, no management UI** — see Phase 1 scope above.
+- **Analytics is the app's responsibility.** ILC assigns and propagates; emitting
+  exposure/conversion events (and any queue/retry) belongs to the consuming app.
+- **No per-variant edge caching.** Experiment responses are `no-store`; a variant-aware
+  cache key would be needed before edge-caching them.
+- **Crawlers are assigned like any visitor.** A deployment that cares should bypass
+  assignment for bots.
 
 ---
 

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -156,7 +156,12 @@ slice boundary rather than reshuffling existing ones.
 
 Assignment is therefore **first-touch sticky**: once a visitor has an `x-ab-<id>` cookie
 they keep their variant, so changing weights mid-experiment only affects not-yet-assigned
-visitors. Read results as a first-touch split, not the current weights.
+visitors. Read results as a first-touch split, not the current weights. The `x-ab-<id>`
+cookie is **re-issued on every request that honours it**, so its 90-day TTL is a sliding
+inactivity window — participation persists as long as visits are less than 90 days apart
+and never lapses mid-experiment for a returning visitor (which matters doubly for
+enrollment-gated experiments, where a lapsed cookie would otherwise drop the visitor out
+until they revisit an enrollment path).
 
 ---
 
@@ -189,10 +194,10 @@ expired. Experiments without a `consentCategory` run unconditionally.
 
 ## Cookies
 
-| Cookie                 | TTL     | Purpose                                                     |
-| ---------------------- | ------- | ----------------------------------------------------------- |
-| `ilc-sid`              | 1 year  | Stable per-visitor id ILC mints itself; the bucketing seed. |
-| `x-ab-<experiment-id>` | 90 days | The resolved variant for one experiment.                    |
+| Cookie                 | TTL                                          | Purpose                                                     |
+| ---------------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| `ilc-sid`              | 1 year                                       | Stable per-visitor id ILC mints itself; the bucketing seed. |
+| `x-ab-<experiment-id>` | 90 days (sliding — refreshed on every visit) | The resolved variant for one experiment.                    |
 
 `ilc-sid` is **HttpOnly** (the client never needs the raw seed). The `x-ab-*` variant
 cookies are readable by the client so it can stay consistent with the server-resolved
@@ -201,7 +206,12 @@ value. Both are `SameSite=Lax` and carry `Secure` when the site is served over h
 cache — the server re-derives assignments from the ruleset every request, and a stored
 value is honoured only when it is still a declared variant, so a tampered cookie can't
 inject an arbitrary value into the page. A response is marked `Cache-Control: private,
-no-store` whenever it carries an assignment or sets a cookie.
+no-store` whenever it carries an assignment or sets a cookie — and, while any
+enrollment- or consent-gated experiment is **active**, on _every_ response: gated
+experiments make personalized and baseline visitors share the same URLs, and a
+shared-cached baseline would otherwise be served to enrolled visitors, silently masking
+their variant. Deployments relying on shared/CDN caching of pages should budget for
+that while a gated experiment runs.
 
 ---
 

--- a/ilc/server/app.spec.js
+++ b/ilc/server/app.spec.js
@@ -373,7 +373,7 @@ describe('App', () => {
             chai.expect(response.headers['cache-control']).to.equal('private, no-store');
         });
 
-        it('reuses an existing assignment and does not re-issue its cookie', async () => {
+        it('reuses an existing assignment, re-issuing its cookie with the same variant (sliding TTL)', async () => {
             const first = await server.get('/').expect(200);
             const firstNames = setCookies(first).map((c) => c.split(';')[0]);
             const sid = firstNames.find((c) => c.startsWith('ilc-sid='));
@@ -382,8 +382,9 @@ describe('App', () => {
             chai.expect(abCookie, 'assignment cookie issued on first visit').to.exist;
 
             const second = await server.get('/').set('Cookie', `${sid}; ${abCookie}`).expect(200);
-            const reissued = setCookies(second).some((c) => c.startsWith('x-ab-example-experiment='));
-            chai.expect(reissued).to.equal(false);
+            const secondNames = setCookies(second).map((c) => c.split(';')[0]);
+            chai.expect(secondNames).to.include(abCookie);
+            chai.expect(secondNames.some((c) => c.startsWith('ilc-sid='))).to.equal(false);
         });
     });
 });

--- a/ilc/server/experiments/assign.spec.ts
+++ b/ilc/server/experiments/assign.spec.ts
@@ -256,4 +256,120 @@ describe('experiments/assign', () => {
             expect(findDirective(result, AB_COOKIE)).to.equal(undefined);
         });
     });
+
+    describe('first-touch enrollment gate', () => {
+        const gatedRuleset: Ruleset = {
+            'homepage-hero': {
+                status: 'active',
+                variants: ruleset['homepage-hero'].variants,
+                enrollment: { paths: ['/sample-nodejs'] },
+            },
+        };
+
+        it('does not enroll a new visitor outside the enrollment paths — no assignment, no cookies at all', () => {
+            const result = assignExperiments(request(), gatedRuleset, { requestPath: '/hosting/plans' });
+
+            expect(result.assignments).to.deep.equal({});
+            expect(result.cookieDirectives).to.have.length(0);
+        });
+
+        it('enrolls a new visitor on an enrollment path and mints both cookies', () => {
+            const result = assignExperiments(request(), gatedRuleset, { requestPath: '/sample-nodejs/experiments' });
+
+            expect(result.assignments).to.have.property('homepage-hero');
+            expect(findDirective(result, AB_COOKIE)).to.not.equal(undefined);
+            expect(findDirective(result, SESSION_COOKIE)).to.not.equal(undefined);
+        });
+
+        it('honours an existing assignment on every route — participation never toggles with navigation', () => {
+            const seed = assignExperiments(request(), gatedRuleset, { requestPath: '/sample-nodejs' });
+            const variant = seed.assignments['homepage-hero'];
+
+            const elsewhere = assignExperiments(
+                request({ [SESSION_COOKIE]: seed.sessionId, [AB_COOKIE]: variant }),
+                gatedRuleset,
+                { requestPath: '/domains/search' },
+            );
+
+            expect(elsewhere.assignments['homepage-hero']).to.equal(variant);
+            expect(elsewhere.cookieDirectives).to.have.length(0);
+        });
+
+        it('fails closed (no enrollment, no throw) on a null enrollment value from untyped config', () => {
+            const broken = {
+                'homepage-hero': {
+                    status: 'active',
+                    variants: ruleset['homepage-hero'].variants,
+                    enrollment: null,
+                },
+            } as unknown as Ruleset;
+
+            const result = assignExperiments(request(), broken, { requestPath: '/sample-nodejs' });
+
+            expect(result.assignments).to.deep.equal({});
+            expect(result.cookieDirectives).to.have.length(0);
+        });
+
+        it('treats the "/" prefix as root-exact — homepage only, not everywhere', () => {
+            const rootGated: Ruleset = {
+                'homepage-hero': {
+                    status: 'active',
+                    variants: ruleset['homepage-hero'].variants,
+                    enrollment: { paths: ['/'] },
+                },
+            };
+
+            const home = assignExperiments(request(), rootGated, { requestPath: '/' });
+            const elsewhere = assignExperiments(request(), rootGated, { requestPath: '/domains' });
+
+            expect(home.assignments).to.have.property('homepage-hero');
+            expect(elsewhere.assignments).to.deep.equal({});
+        });
+
+        it('matches path prefixes on segment boundaries only', () => {
+            const inside = assignExperiments(request(), gatedRuleset, { requestPath: '/sample-nodejs' });
+            const lookalike = assignExperiments(request(), gatedRuleset, { requestPath: '/sample-nodejs-evil' });
+
+            expect(inside.assignments).to.have.property('homepage-hero');
+            expect(lookalike.assignments).to.deep.equal({});
+        });
+
+        it('enrolls anywhere when the enrollment field is absent (back-compat)', () => {
+            const result = assignExperiments(request(), ruleset, { requestPath: '/anywhere' });
+
+            expect(result.assignments).to.have.property('homepage-hero');
+        });
+
+        it('fails closed for new visitors when requestPath is not provided', () => {
+            const result = assignExperiments(request(), gatedRuleset);
+
+            expect(result.assignments).to.deep.equal({});
+            expect(result.cookieDirectives).to.have.length(0);
+        });
+
+        it('sweeps a tampered cookie outside enrollment paths without re-enrolling', () => {
+            const result = assignExperiments(
+                request({ [SESSION_COOKIE]: 'sid-1', [AB_COOKIE]: 'not-a-variant' }),
+                gatedRuleset,
+                { requestPath: '/domains' },
+            );
+
+            expect(result.assignments).to.deep.equal({});
+            const expire = findDirective(result, AB_COOKIE);
+            expect(expire?.options.maxAge).to.equal(0);
+        });
+
+        it('gates experiments independently in a mixed ruleset', () => {
+            const mixed: Ruleset = {
+                ...gatedRuleset,
+                'global-exp': { status: 'active', variants: ruleset['homepage-hero'].variants },
+            };
+
+            const result = assignExperiments(request(), mixed, { requestPath: '/domains' });
+
+            expect(result.assignments).to.not.have.property('homepage-hero');
+            expect(result.assignments).to.have.property('global-exp');
+            expect(findDirective(result, SESSION_COOKIE)).to.not.equal(undefined);
+        });
+    });
 });

--- a/ilc/server/experiments/assign.spec.ts
+++ b/ilc/server/experiments/assign.spec.ts
@@ -53,7 +53,7 @@ describe('experiments/assign', () => {
     });
 
     describe('returning visit (cookies present)', () => {
-        it('reuses the existing session id and variant, emitting no new cookies', () => {
+        it('reuses the existing session id and variant, refreshing the assignment cookie (sliding TTL)', () => {
             const first = assignExperiments(request(), ruleset);
             const sessionId = first.sessionId;
             const variant = first.assignments['homepage-hero'];
@@ -62,7 +62,10 @@ describe('experiments/assign', () => {
 
             expect(second.sessionId).to.equal(sessionId);
             expect(second.assignments).to.deep.equal(first.assignments);
-            expect(second.cookieDirectives).to.have.length(0);
+            const refreshed = findDirective(second, AB_COOKIE);
+            expect(refreshed?.value).to.equal(variant);
+            expect(refreshed?.options.maxAge).to.be.greaterThan(0);
+            expect(findDirective(second, SESSION_COOKIE)).to.equal(undefined);
         });
 
         it('is stable across many re-evaluations of the same session', () => {
@@ -246,14 +249,16 @@ describe('experiments/assign', () => {
             expect(expire?.options.maxAge).to.equal(0);
         });
 
-        it('leaves the cookie of a live assignment untouched (no spurious expiry)', () => {
+        it('refreshes (never expires) the cookie of a live assignment', () => {
             const seed = assignExperiments(request(), ruleset);
             const variant = seed.assignments['homepage-hero'];
             const result = assignExperiments(
                 request({ [SESSION_COOKIE]: seed.sessionId, [AB_COOKIE]: variant }),
                 ruleset,
             );
-            expect(findDirective(result, AB_COOKIE)).to.equal(undefined);
+            const directive = findDirective(result, AB_COOKIE);
+            expect(directive?.value).to.equal(variant);
+            expect(directive?.options.maxAge).to.be.greaterThan(0);
         });
     });
 
@@ -292,7 +297,10 @@ describe('experiments/assign', () => {
             );
 
             expect(elsewhere.assignments['homepage-hero']).to.equal(variant);
-            expect(elsewhere.cookieDirectives).to.have.length(0);
+            const refreshed = findDirective(elsewhere, AB_COOKIE);
+            expect(refreshed?.value).to.equal(variant);
+            expect(refreshed?.options.maxAge).to.be.greaterThan(0);
+            expect(findDirective(elsewhere, SESSION_COOKIE)).to.equal(undefined);
         });
 
         it('fails closed (no enrollment, no throw) on a null enrollment value from untyped config', () => {
@@ -321,9 +329,26 @@ describe('experiments/assign', () => {
 
             const home = assignExperiments(request(), rootGated, { requestPath: '/' });
             const elsewhere = assignExperiments(request(), rootGated, { requestPath: '/domains' });
+            const doubleSlash = assignExperiments(request(), rootGated, { requestPath: '//domains' });
 
             expect(home.assignments).to.have.property('homepage-hero');
             expect(elsewhere.assignments).to.deep.equal({});
+            expect(doubleSlash.assignments).to.deep.equal({});
+        });
+
+        it('fails closed on an empty-string enrollment prefix (validation only warns)', () => {
+            const emptyPrefix: Ruleset = {
+                'homepage-hero': {
+                    status: 'active',
+                    variants: ruleset['homepage-hero'].variants,
+                    enrollment: { paths: [''] },
+                },
+            };
+
+            const result = assignExperiments(request(), emptyPrefix, { requestPath: '/anywhere' });
+
+            expect(result.assignments).to.deep.equal({});
+            expect(result.cookieDirectives).to.have.length(0);
         });
 
         it('matches path prefixes on segment boundaries only', () => {

--- a/ilc/server/experiments/assign.ts
+++ b/ilc/server/experiments/assign.ts
@@ -36,9 +36,14 @@ function readCookies(request: MinimalRequest): ParsedCookies {
 // `/shopping`. A configured prefix may carry a trailing slash; it is normalised away.
 // `/` is deliberately root-exact (matches only the homepage): "enroll everywhere" is
 // expressed by omitting `enrollment`, so `/` covering all paths would be redundant
-// while making a homepage-only gate inexpressible.
+// while making a homepage-only gate inexpressible. Root-exact means STRICT equality —
+// this runs before any URL normalisation, so a raw `//domains` must not match `/`
+// via the `startsWith('//')` shape of the generic prefix check below.
 function pathMatchesPrefix(path: string, prefix: string): boolean {
     const normalised = prefix.endsWith('/') && prefix !== '/' ? prefix.slice(0, -1) : prefix;
+    if (normalised === '/') {
+        return path === '/';
+    }
     return path === normalised || path.startsWith(`${normalised}/`);
 }
 
@@ -58,7 +63,13 @@ function isEnrollable(experiment: Experiment, requestPath: string | undefined): 
     if (!enrollment || !Array.isArray(enrollment.paths) || requestPath === undefined) {
         return false;
     }
-    return enrollment.paths.some((prefix) => typeof prefix === 'string' && pathMatchesPrefix(requestPath, prefix));
+    // Mirror the validator's rule at runtime: only non-empty, `/`-prefixed strings can
+    // match. Validation merely WARNS about a malformed ruleset (the provider still loads
+    // it), and without this check an empty-string prefix would match every path via
+    // `startsWith('/')` — enrolling the whole site, the opposite of fail-closed.
+    return enrollment.paths.some(
+        (prefix) => typeof prefix === 'string' && prefix.startsWith('/') && pathMatchesPrefix(requestPath, prefix),
+    );
 }
 
 /**
@@ -129,6 +140,16 @@ export function assignExperiments(
 
         if (isStoredVariantValid) {
             assignments[experimentId] = stored as string;
+            // Sliding refresh: re-issue the cookie so its Max-Age counts from the LAST
+            // visit, not first touch. Without this, participation silently lapses after
+            // 90 days — the visitor gets re-bucketed (a reweight could then flip their
+            // variant), and an enrollment-gated visitor drops out of the experiment
+            // entirely until they happen to revisit an enrollment path.
+            cookieDirectives.push({
+                name: abCookieName(experimentId),
+                value: stored as string,
+                options: abCookieOptions(secure),
+            });
             continue;
         }
 

--- a/ilc/server/experiments/assign.ts
+++ b/ilc/server/experiments/assign.ts
@@ -9,7 +9,14 @@ import {
     expireCookieOptions,
     sessionCookieOptions,
 } from './cookies';
-import type { AssignmentResult, AssignOptions, CookieDirective, ExperimentAssignments, Ruleset } from './interfaces';
+import type {
+    AssignmentResult,
+    AssignOptions,
+    CookieDirective,
+    Experiment,
+    ExperimentAssignments,
+    Ruleset,
+} from './interfaces';
 
 // Cookie names/options live in ./cookies; re-exported here as the layer's public surface.
 export { SESSION_COOKIE, AB_COOKIE_PREFIX, abCookieName } from './cookies';
@@ -23,6 +30,35 @@ type ParsedCookies = Record<string, string | undefined>;
 function readCookies(request: MinimalRequest): ParsedCookies {
     const header = request.headers.cookie;
     return header ? parseCookieHeader(header) : {};
+}
+
+// Segment-aligned prefix match: `/shop` covers `/shop` and `/shop/cart` but not
+// `/shopping`. A configured prefix may carry a trailing slash; it is normalised away.
+// `/` is deliberately root-exact (matches only the homepage): "enroll everywhere" is
+// expressed by omitting `enrollment`, so `/` covering all paths would be redundant
+// while making a homepage-only gate inexpressible.
+function pathMatchesPrefix(path: string, prefix: string): boolean {
+    const normalised = prefix.endsWith('/') && prefix !== '/' ? prefix.slice(0, -1) : prefix;
+    return path === normalised || path.startsWith(`${normalised}/`);
+}
+
+/**
+ * First-touch enrollment gate. Applies ONLY to visitors without a valid stored
+ * assignment — the stored-cookie path above it is deliberately not gated, so an
+ * enrolled visitor keeps their variant on every route (this is what makes the field an
+ * enrollment gate and not a route-scoped experiment). Defensive like the rest of the
+ * layer: a malformed `enrollment` value fails closed (no new enrollment) rather than
+ * throwing, and an absent field enrolls everywhere (pre-existing behaviour).
+ */
+function isEnrollable(experiment: Experiment, requestPath: string | undefined): boolean {
+    const enrollment = experiment.enrollment;
+    if (enrollment === undefined) {
+        return true;
+    }
+    if (!enrollment || !Array.isArray(enrollment.paths) || requestPath === undefined) {
+        return false;
+    }
+    return enrollment.paths.some((prefix) => typeof prefix === 'string' && pathMatchesPrefix(requestPath, prefix));
 }
 
 /**
@@ -50,7 +86,7 @@ function readCookies(request: MinimalRequest): ParsedCookies {
 export function assignExperiments(
     request: MinimalRequest,
     ruleset: Ruleset,
-    { secure = false, resolveConsent }: AssignOptions = {},
+    { secure = false, resolveConsent, requestPath }: AssignOptions = {},
 ): AssignmentResult {
     const cookies = readCookies(request);
 
@@ -93,6 +129,14 @@ export function assignExperiments(
 
         if (isStoredVariantValid) {
             assignments[experimentId] = stored as string;
+            continue;
+        }
+
+        // First-touch enrollment gate: below this line we are about to bucket a NEW
+        // participant. Gated experiments recruit only on their enrollment paths; the
+        // stored-assignment path above stays ungated so participation never toggles
+        // with navigation (not a per-route experiment).
+        if (!isEnrollable(experiment, requestPath)) {
             continue;
         }
 

--- a/ilc/server/experiments/index.spec.ts
+++ b/ilc/server/experiments/index.spec.ts
@@ -106,21 +106,58 @@ describe('experiments/index applyExperiments', () => {
             expect(cacheControl(reply)).to.equal('private, no-store');
         });
 
-        it('marks the response uncacheable even for a returning visitor with no new cookies', () => {
-            // sticky cookie already present -> no Set-Cookie, but the page still varies by variant
+        it('marks the response uncacheable for a returning visitor and refreshes their sticky cookie', () => {
             const reply = makeReply();
             applyExperiments(
                 makeRequest(`${SESSION_COOKIE}=sid-1; ${abCookieName('homepage-hero')}=variant-b`),
                 reply,
                 ruleset,
             );
-            expect(setCookies(reply)).to.have.length(0);
+            const cookies = setCookies(reply);
+            expect(cookies).to.have.length(1);
+            expect(cookies[0].startsWith(`${abCookieName('homepage-hero')}=variant-b`)).to.equal(true);
             expect(cacheControl(reply)).to.equal('private, no-store');
         });
 
         it('does NOT touch Cache-Control when nothing was assigned or set (page stays cacheable)', () => {
             const reply = makeReply();
             applyExperiments(makeRequest(`${SESSION_COOKIE}=sid-1`), reply, {});
+            expect(cacheControl(reply)).to.equal(undefined);
+        });
+
+        it('marks even an unassigned baseline no-store while an enrollment-gated experiment is active', () => {
+            const gated: Ruleset = {
+                'homepage-hero': { ...ruleset['homepage-hero'], enrollment: { paths: ['/promo'] } },
+            };
+            const reply = makeReply();
+            applyExperiments(makeRequest(), reply, gated);
+
+            expect(setCookies(reply)).to.have.length(0);
+            expect(cacheControl(reply)).to.equal('private, no-store');
+        });
+
+        it('marks even an unassigned baseline no-store while a consent-gated experiment is active', () => {
+            const gated: Ruleset = {
+                'homepage-hero': { ...ruleset['homepage-hero'], consentCategory: 'performance' },
+            };
+            const reply = makeReply();
+            applyExperiments(makeRequest(), reply, gated);
+
+            expect(setCookies(reply)).to.have.length(0);
+            expect(cacheControl(reply)).to.equal('private, no-store');
+        });
+
+        it('leaves the response cacheable when the only gated experiment is paused', () => {
+            const paused: Ruleset = {
+                'homepage-hero': {
+                    ...ruleset['homepage-hero'],
+                    status: 'paused',
+                    enrollment: { paths: ['/promo'] },
+                },
+            };
+            const reply = makeReply();
+            applyExperiments(makeRequest(), reply, paused);
+
             expect(cacheControl(reply)).to.equal(undefined);
         });
     });

--- a/ilc/server/experiments/index.ts
+++ b/ilc/server/experiments/index.ts
@@ -25,6 +25,26 @@ function forwardedProtoIsHttps(request: PatchedFastifyRequest): boolean {
     return typeof value === 'string' && value.split(',')[0].trim().toLowerCase() === 'https';
 }
 
+/**
+ * True when any active experiment can split visitors into personalized and baseline
+ * populations on the SAME URL — an `enrollment` gate (unenrolled visitors get baseline)
+ * or a `consentCategory` (denied/unknown visitors get baseline). While such an
+ * experiment is live, even a fully inert baseline response must be uncacheable:
+ * a shared cache/CDN would otherwise store the baseline under the bare URL and serve it
+ * to an *enrolled* visitor, whose request then never reaches the origin — masking their
+ * stored assignment and breaking the "enrolled on every route" guarantee. Ungated,
+ * unconditioned experiments personalize every response, so they are already `no-store`
+ * per response and don't need this; an empty ruleset stays fully inert (cacheable).
+ */
+function rulesetSplitsPopulation(ruleset: Ruleset): boolean {
+    return Object.values(ruleset).some(
+        (experiment) =>
+            !!experiment &&
+            experiment.status === 'active' &&
+            (experiment.enrollment !== undefined || experiment.consentCategory !== undefined),
+    );
+}
+
 /** Append one `Set-Cookie` header without clobbering cookies set earlier in the request. */
 function appendSetCookie(reply: ServerResponseFastifyReply, serialized: string): void {
     const existing = reply.raw.getHeader('Set-Cookie');
@@ -60,7 +80,11 @@ function appendSetCookie(reply: ServerResponseFastifyReply, serialized: string):
  * When the response is personalized (a variant is assigned or a cookie is minted)
  * it is marked `Cache-Control: private, no-store` so a shared cache/CDN can't serve
  * one visitor's variant — or a single minted session id — to everyone. Without this
- * an upstream cache keyed on the URL would collapse the whole experiment.
+ * an upstream cache keyed on the URL would collapse the whole experiment. The same
+ * header is applied to *baseline* responses while any enrollment- or consent-gated
+ * experiment is active (see {@link rulesetSplitsPopulation}): those experiments make
+ * personalized and baseline visitors share URLs, and a cached baseline would be served
+ * to enrolled visitors, masking their stored assignment.
  *
  * @param rulesetOverride test seam — defaults to the active {@link defaultRulesetProvider}.
  *   Read per call so a future provider with a live (background-synced) cache is picked up.
@@ -104,7 +128,7 @@ export function applyExperiments(
 
     // The response now varies per visitor (a resolved variant) or carries a freshly
     // minted session id — either way it must not be shared-cached.
-    if (Object.keys(assignments).length > 0 || cookieDirectives.length > 0) {
+    if (Object.keys(assignments).length > 0 || cookieDirectives.length > 0 || rulesetSplitsPopulation(ruleset)) {
         reply.raw.setHeader('Cache-Control', 'private, no-store');
     }
 }

--- a/ilc/server/experiments/index.ts
+++ b/ilc/server/experiments/index.ts
@@ -88,6 +88,8 @@ export function applyExperiments(
     const { assignments, cookieDirectives } = assignExperiments(request.raw, ruleset, {
         secure,
         resolveConsent: (category) => resolveConsent(request.raw, category),
+        // Raw request path (query stripped) for the first-touch `enrollment` gate.
+        requestPath: request.raw.url?.split('?')[0],
     });
 
     // Only attach `experiments` when something was actually assigned — keeps the

--- a/ilc/server/experiments/interfaces.ts
+++ b/ilc/server/experiments/interfaces.ts
@@ -32,6 +32,27 @@ export type ExperimentStatus = 'active' | 'paused';
  */
 export type ConsentState = 'granted' | 'denied' | 'unknown';
 
+/**
+ * Optional gate on *first-time enrollment only*. When set, a visitor is bucketed into
+ * the experiment (and gets the sticky `x-ab-<id>` cookie) only while requesting one of
+ * the listed path prefixes. Visitors who never hit an enrollment path stay fully out of
+ * the experiment — no assignment, no cookies.
+ *
+ * This is NOT a route-scoped experiment: once a visitor is enrolled, the stored
+ * assignment is honoured on every route (the stored-cookie path is deliberately not
+ * gated), so participation never toggles with navigation. The gate narrows *who joins
+ * the population*, not *where the experiment applies*.
+ *
+ * Paths are matched as segment-aligned prefixes against the raw request path (query
+ * string excluded, before any i18n un-localisation): `/shop` matches `/shop` and
+ * `/shop/cart`, but not `/shopping`. Localised URL prefixes must be listed explicitly.
+ * `/` is root-exact — it gates enrollment to the homepage only; to enroll everywhere,
+ * omit `enrollment` entirely.
+ */
+export interface ExperimentEnrollment {
+    readonly paths: readonly string[];
+}
+
 export interface Experiment {
     readonly status: ExperimentStatus;
     readonly variants: readonly ExperimentVariant[];
@@ -43,6 +64,11 @@ export interface Experiment {
      * fail-closed (not assigned). Experiments without a category run unconditionally.
      */
     readonly consentCategory?: string;
+    /**
+     * Optional first-touch enrollment gate (see {@link ExperimentEnrollment}). Absent —
+     * visitors enroll on any route, exactly as before this field existed.
+     */
+    readonly enrollment?: ExperimentEnrollment;
 }
 
 /** The complete set of experiments ILC knows about, keyed by experiment id. */
@@ -91,6 +117,12 @@ export interface AssignOptions {
      * Experiments without a `consentCategory` ignore this entirely.
      */
     readonly resolveConsent?: (category: string) => ConsentState;
+    /**
+     * Path of the current request (no query string), used by the `enrollment` gate.
+     * When omitted, enrollment-gated experiments are fail-closed for *new* visitors
+     * (no first-time bucketing), while stored assignments are still honoured.
+     */
+    readonly requestPath?: string;
 }
 
 /** A cookie the caller must write to the response to persist assignment state. */

--- a/ilc/server/experiments/validate.spec.ts
+++ b/ilc/server/experiments/validate.spec.ts
@@ -75,4 +75,60 @@ describe('experiments/validate', () => {
         const ruleset: Ruleset = { exp: { status: 'active', variants: [] } };
         expect(validateRuleset(ruleset).some((p) => p.includes('no variants'))).to.equal(true);
     });
+
+    it('accepts a well-formed enrollment gate', () => {
+        const ruleset: Ruleset = {
+            exp: {
+                status: 'active',
+                variants: [
+                    { name: 'a', weight: 50 },
+                    { name: 'b', weight: 50 },
+                ],
+                enrollment: { paths: ['/sample-nodejs'] },
+            },
+        };
+        expect(validateRuleset(ruleset)).to.deep.equal([]);
+    });
+
+    it('flags an empty enrollment.paths (would never enroll anyone)', () => {
+        const ruleset: Ruleset = {
+            exp: {
+                status: 'active',
+                variants: [
+                    { name: 'a', weight: 50 },
+                    { name: 'b', weight: 50 },
+                ],
+                enrollment: { paths: [] },
+            },
+        };
+        expect(validateRuleset(ruleset).some((p) => p.includes('enrollment.paths'))).to.equal(true);
+    });
+
+    it('flags a null enrollment value without throwing', () => {
+        const ruleset = {
+            exp: {
+                status: 'active',
+                variants: [
+                    { name: 'a', weight: 50 },
+                    { name: 'b', weight: 50 },
+                ],
+                enrollment: null,
+            },
+        } as unknown as Ruleset;
+        expect(validateRuleset(ruleset).some((p) => p.includes('enrollment.paths'))).to.equal(true);
+    });
+
+    it('flags an enrollment path without a leading slash', () => {
+        const ruleset: Ruleset = {
+            exp: {
+                status: 'active',
+                variants: [
+                    { name: 'a', weight: 50 },
+                    { name: 'b', weight: 50 },
+                ],
+                enrollment: { paths: ['sample-nodejs'] },
+            },
+        };
+        expect(validateRuleset(ruleset).some((p) => p.includes('starting with "/"'))).to.equal(true);
+    });
 });

--- a/ilc/server/experiments/validate.ts
+++ b/ilc/server/experiments/validate.ts
@@ -42,6 +42,21 @@ function checkVariant(experimentId: string, variant: ExperimentVariant): string[
     return [];
 }
 
+function checkEnrollment(experimentId: string, experiment: Experiment): string[] {
+    const { enrollment } = experiment;
+    if (enrollment === undefined) {
+        return [];
+    }
+    if (!enrollment || !Array.isArray(enrollment.paths) || enrollment.paths.length === 0) {
+        return [
+            `"${experimentId}": enrollment.paths must be a non-empty array of path prefixes — new visitors will never enroll`,
+        ];
+    }
+    return enrollment.paths
+        .filter((path) => typeof path !== 'string' || !path.startsWith('/'))
+        .map((path) => `"${experimentId}": enrollment path "${String(path)}" must be a string starting with "/"`);
+}
+
 function checkVariants(experimentId: string, variants: readonly ExperimentVariant[]): string[] {
     const problems: string[] = [];
     const names = new Set<string>();
@@ -86,6 +101,7 @@ export function validateRuleset(ruleset: Ruleset): string[] {
         }
 
         problems.push(...checkStatus(experimentId, experiment));
+        problems.push(...checkEnrollment(experimentId, experiment));
 
         const { variants } = experiment;
         if (!Array.isArray(variants) || variants.length === 0) {


### PR DESCRIPTION
- Add an optional `enrollment: { paths: [...] }` field to experiment definitions — gated
experiments recruit **new** participants only on the listed path prefixes
(segment-aligned, `/` is root-exact), while already-enrolled visitors keep their variant
on every route. Absent field = enroll anywhere, exactly as before.
re-issued on every honoured request (sliding 90-day TTL, so participation can't silently
lapse), and every response is `private, no-store` while a population-splitting
(enrollment- or consent-gated) experiment is active, so a shared-cached baseline can
never mask an enrolled visitor's variant. Documented in `docs/ab-testing.md`.